### PR TITLE
[issue 37] naïve and simplistic storage for blocks

### DIFF
--- a/layer1/Makefile
+++ b/layer1/Makefile
@@ -11,8 +11,9 @@ build:
 	mkdir -p $(LAYER1_BUILD_DIR)
 
 	make -C wallet build
-	make -C mint build
+	make -C mint build 
 	make -C refutation build
+	make -C chain build
 
 test:
 	$(LIGO_TEST) test/test.mligo

--- a/layer1/chain/Makefile
+++ b/layer1/chain/Makefile
@@ -1,0 +1,5 @@
+
+.PHONY:build
+build:
+	$(LIGO_BUILD) chain/src/chain_sc.mligo > $(LAYER1_BUILD_DIR)/chain_sc.tez
+

--- a/layer1/chain/src/chain.mligo
+++ b/layer1/chain/src/chain.mligo
@@ -25,7 +25,7 @@ let is_batch_valid (batch, store : batch * chain) : bool =
     | None -> false
     | Some parent -> parent.level < batch.level )
 
-let store_batch (batch, chain : batch * chain) : chain =
+let store_batch (batch, chain : batch * chain) : chain option =
     let add_to_children (newborn, parent, chain : index * index * chain) : (index, index list)  big_map  =
         let new_children = 
             match get_children (parent, chain) with
@@ -36,17 +36,12 @@ let store_batch (batch, chain : batch * chain) : chain =
     in
     if is_batch_valid (batch,chain) then
         let new_index = chain.max_index + 1n in
-        { chain with 
+        Some ({ chain with 
               batches = Big_map.update new_index (Some batch) chain.batches 
             ; max_index =  new_index
             ; children = add_to_children (new_index, batch.parent, chain)
-        }
-    else failwith "could not store invalid batch"
-
-let get_latest_batch (store : chain) : batch =
-    match get_batch (store.max_index, store) with
-    | None -> failwith "no batch"
-    | Some b -> b
+        })
+    else (None : chain option)// FIXME: use Result module to add information "could not store invalid batch"
 
 let remove_batch (index, chain: index * chain) : chain =
     let delete_batch (chain, index: chain * index) : chain =

--- a/layer1/chain/src/chain.mligo
+++ b/layer1/chain/src/chain.mligo
@@ -32,7 +32,7 @@ let store_batch (batch, chain : batch * chain) : chain option =
         let new_children = 
             match get_children (parent, chain) with
             | None ->  [newborn]
-            | Some sibligns -> newborn :: sibligns
+            | Some siblings -> newborn :: siblings
         in
         Big_map.update parent (Some new_children) chain.children
     in

--- a/layer1/chain/src/chain.mligo
+++ b/layer1/chain/src/chain.mligo
@@ -1,0 +1,77 @@
+#import "../../stdlib_ext/src/stdlibext.mligo" "Stdlib"
+
+type hash = bytes
+type index = nat
+type batch = 
+    {  parent : index
+    ;  level : nat
+    ;  hash : hash
+    ;  proposer : address
+    }
+type chain = 
+    {   max_index : nat
+    ;   batches : (index, batch) big_map
+    ;   children : (index, index list) big_map
+    }
+
+    
+let get_batch (index, store : index * chain) : batch option = Big_map.find_opt index store.batches
+let get_children (index, store : index * chain) : index list option = Big_map.find_opt index store.children
+
+let is_batch_valid (batch, store : batch * chain) : bool = 
+    batch.parent = 0n ||
+    ( let parent_opt = get_batch (batch.parent, store) in
+    match parent_opt with
+    | None -> false
+    | Some parent -> parent.level < batch.level )
+
+let store_batch (batch, chain : batch * chain) : chain =
+    let add_to_children (newborn, parent, chain : index * index * chain) : (index, index list)  big_map  =
+        let new_children = 
+            match get_children (parent, chain) with
+            | None ->  [newborn]
+            | Some sibligns -> newborn :: sibligns
+        in
+        Big_map.update parent (Some new_children) chain.children
+    in
+    if is_batch_valid (batch,chain) then
+        let new_index = chain.max_index + 1n in
+        { chain with 
+              batches = Big_map.update new_index (Some batch) chain.batches 
+            ; max_index =  new_index
+            ; children = add_to_children (new_index, batch.parent, chain)
+        }
+    else failwith "could not store invalid batch"
+
+let get_latest_batch (store : chain) : batch =
+    match get_batch (store.max_index, store) with
+    | None -> failwith "no batch"
+    | Some b -> b
+
+let remove_batch (index, chain: index * chain) : chain =
+    let delete_batch (chain, index: chain * index) : chain =
+        {chain with batches = Big_map.update index (None : batch option) chain.batches} 
+    in
+    let rec aux (to_delete, chain : index list * chain) : chain = 
+        match to_delete with
+        | [] -> chain
+        | i::q -> 
+            begin
+            let children = Big_map.find_opt i chain.children in
+            let chain = delete_batch (chain, i) in
+            match children with
+            | None -> aux (q, chain)
+            | Some children -> aux (Stdlib.ListExt.concat children q, chain)
+            end
+    in
+    aux ([index],chain)
+
+let find_latest_existing (chain : chain) : batch option = 
+    let rec find_existing (index : index) : batch option =
+        if index = 0n then (None : batch option)
+        else match Big_map.find_opt index chain.batches with
+            | None -> find_existing (abs(index - 1n))
+            | Some batch -> Some batch
+    in
+    let max_index = chain.max_index in
+    find_existing max_index

--- a/layer1/chain/src/chain.mligo
+++ b/layer1/chain/src/chain.mligo
@@ -30,7 +30,7 @@ let is_block_valid (block, chain : block * chain) : bool =
     | None -> false
     | Some parent -> parent.level < block.level )
 
-(* [store_block (block,chain)] stores a block in the chain, checking validity, referencing it as a children. *)
+(* [store_block (block,chain)] stores a block in the chain, checks validity, references it as a child. *)
 let store_block (block, chain : block * chain) : (chain, chain_error) result =
     let add_to_children (newborn, parent, chain : index * index * chain) : (index, index list)  big_map  =
         let new_children = 
@@ -49,7 +49,7 @@ let store_block (block, chain : block * chain) : (chain, chain_error) result =
         })
     else Error Invalid_block
 
-(* [remove_block (index,chain)] remove block at rank [index] from [chain]. Removes the children also. *)
+(* [remove_block (index,chain)] removes block at rank [index] from [chain]. Removes the children also. *)
 let remove_block (index, chain: index * chain) : chain =
     let delete_block (chain, index: chain * index) : chain =
         {chain with blocks = Big_map.update index (None : block option) chain.blocks} 

--- a/layer1/chain/src/chain.mligo
+++ b/layer1/chain/src/chain.mligo
@@ -9,7 +9,7 @@ type batch =
     ;  proposer : address
     }
 type chain = 
-    {   max_index : nat                         // max_index is the biggest index ever used. Not necessarily the biggest still used, as the corresponding batch could have been removed.
+    {   max_index : index                         // max_index is the biggest index ever used. Not necessarily the biggest still used, as the corresponding batch could have been removed.
     ;   batches : (index, batch) big_map        // stores the batches
     ;   children : (index, index list) big_map  // stores the children of a batch, i.e. the index of the batches that designated it as immediat parent
     }
@@ -74,3 +74,4 @@ let find_latest_existing (chain : chain) : batch option =
     in
     let max_index = chain.max_index in
     find_existing max_index
+

--- a/layer1/chain/src/chain.mligo
+++ b/layer1/chain/src/chain.mligo
@@ -2,36 +2,36 @@
 #import "../../stdlib_ext/src/result.mligo" "Stdlib_Result"
 type hash = bytes
 type index = nat
-type batch = 
+type block = 
     {  parent : index
     ;  level : nat
     ;  hash : hash
     ;  proposer : address
     }
 type chain = 
-    {   max_index : index                         // max_index is the biggest index ever used. Not necessarily the biggest still used, as the corresponding batch could have been removed.
-    ;   batches : (index, batch) big_map        // stores the batches
-    ;   children : (index, index list) big_map  // stores the children of a batch, i.e. the index of the batches that designated it as immediat parent
+    {   max_index : index                         // max_index is the biggest index ever used. Not necessarily the biggest still used, as the corresponding block could have been removed.
+    ;   blocks : (index, block) big_map        // stores the blocks
+    ;   children : (index, index list) big_map  // stores the children of a block, i.e. the index of the blocks that designated it as immediat parent
     }
 
 (* error type *) // FIXME: pretty minimal, if as no more value with finalization, relevance should be reexamined
 type chain_error = 
-    | Invalid_batch
+    | Invalid_block
 type result = Stdlib_Result.t
     
-let get_batch (index, store : index * chain) : batch option = Big_map.find_opt index store.batches
+let get_block (index, store : index * chain) : block option = Big_map.find_opt index store.blocks
 let get_children (index, store : index * chain) : index list option = Big_map.find_opt index store.children
 
-(* [is_batch_valid (batch, chain)] checks that a batch is at least well formed *)
-let is_batch_valid (batch, chain : batch * chain) : bool = 
-    batch.parent = 0n || // takes care of the first batch ever
-    ( let parent_opt = get_batch (batch.parent, chain) in
+(* [is_block_valid (block, chain)] checks that a block is at least well formed *)
+let is_block_valid (block, chain : block * chain) : bool = 
+    block.parent = 0n || // takes care of the first block ever
+    ( let parent_opt = get_block (block.parent, chain) in
     match parent_opt with
     | None -> false
-    | Some parent -> parent.level < batch.level )
+    | Some parent -> parent.level < block.level )
 
-(* [store_batch (batch,chain)] stores a batch in the chain, checking validity, referencing it as a children. *)
-let store_batch (batch, chain : batch * chain) : (chain, chain_error) result =
+(* [store_block (block,chain)] stores a block in the chain, checking validity, referencing it as a children. *)
+let store_block (block, chain : block * chain) : (chain, chain_error) result =
     let add_to_children (newborn, parent, chain : index * index * chain) : (index, index list)  big_map  =
         let new_children = 
             match get_children (parent, chain) with
@@ -40,19 +40,19 @@ let store_batch (batch, chain : batch * chain) : (chain, chain_error) result =
         in
         Big_map.update parent (Some new_children) chain.children
     in
-    if is_batch_valid (batch,chain) then
+    if is_block_valid (block,chain) then
         let new_index = chain.max_index + 1n in
         Ok ({ chain with 
-              batches = Big_map.update new_index (Some batch) chain.batches 
+              blocks = Big_map.update new_index (Some block) chain.blocks 
             ; max_index =  new_index
-            ; children = add_to_children (new_index, batch.parent, chain)
+            ; children = add_to_children (new_index, block.parent, chain)
         })
-    else Error Invalid_batch
+    else Error Invalid_block
 
-(* [remove_batch (index,chain)] remove batch at rank [index] from [chain]. Removes the children also. *)
-let remove_batch (index, chain: index * chain) : chain =
-    let delete_batch (chain, index: chain * index) : chain =
-        {chain with batches = Big_map.update index (None : batch option) chain.batches} 
+(* [remove_block (index,chain)] remove block at rank [index] from [chain]. Removes the children also. *)
+let remove_block (index, chain: index * chain) : chain =
+    let delete_block (chain, index: chain * index) : chain =
+        {chain with blocks = Big_map.update index (None : block option) chain.blocks} 
     in
     let rec aux (to_delete, chain : index list * chain) : chain = 
         match to_delete with
@@ -60,7 +60,7 @@ let remove_batch (index, chain: index * chain) : chain =
         | i::q -> 
             begin
             let children = Big_map.find_opt i chain.children in
-            let chain = delete_batch (chain, i) in
+            let chain = delete_block (chain, i) in
             match children with
             | None -> aux (q, chain)
             | Some children -> aux (Stdlib.ListExt.concat children q, chain)
@@ -68,13 +68,13 @@ let remove_batch (index, chain: index * chain) : chain =
     in
     aux ([index],chain)
 
-(* [find_latest_existing (chain)] finds the batch of biggest index, that is still present in chain. *)
-let find_latest_existing (chain : chain) : batch option = 
-    let rec find_existing (index : index) : batch option =
-        if index = 0n then (None : batch option)
-        else match Big_map.find_opt index chain.batches with
+(* [find_latest_existing (chain)] finds the block of biggest index, that is still present in chain. *)
+let find_latest_existing (chain : chain) : block option = 
+    let rec find_existing (index : index) : block option =
+        if index = 0n then (None : block option)
+        else match Big_map.find_opt index chain.blocks with
             | None -> find_existing (abs(index - 1n))
-            | Some batch -> Some batch
+            | Some block -> Some block
     in
     let max_index = chain.max_index in
     find_existing max_index

--- a/layer1/chain/src/chain_sc.mligo
+++ b/layer1/chain/src/chain_sc.mligo
@@ -1,0 +1,39 @@
+type hash = bytes
+type index = nat
+type batch = 
+    {  parent : index
+    ;  level : nat
+    ;  hash : hash
+    ;  proposer : address
+    }
+
+type chain_storage = 
+    {   max_index : nat
+    ;   batches : (index, batch) map
+    }
+
+type chain_parameter = 
+    | Receive of batch
+    
+let is_batch_valid (batch, store : batch * chain_storage) : bool = true
+
+let store_batch (batch, store : batch * chain_storage) : chain_storage =
+    if is_batch_valid (batch,store) then
+        {store with 
+              batches = Map.update store.max_index (Some batch) store.batches 
+            ; max_index = store.max_index + 1n 
+        }
+    else store
+
+let get_latest_batch (store : chain_storage) : batch =
+    match Map.find_opt store.max_index store.batches with
+    | None -> failwith "no batch"
+    | Some b -> b
+
+(* ENDPOINTS *)
+let main (action, store : chain_parameter * chain_storage) : operation list * chain_storage = 
+    match action with
+    | Receive b -> [] , store_batch (b, store)
+
+[@view] let get_chain ((),s: unit * chain_storage) : chain_storage = s
+[@view] let get_latest ((),s: unit * chain_storage) : batch = get_latest_batch s

--- a/layer1/chain/src/chain_sc.mligo
+++ b/layer1/chain/src/chain_sc.mligo
@@ -1,7 +1,12 @@
+(*
+    This smart contract is used only as a placeholder to try the /chain/ library. 
+*)
+
 #include "chain.mligo"
 type chain_storage = chain
 type chain_parameter = 
     | Receive of batch
+    | Remove  of index
 
 (* ENDPOINTS *)
 let main (action, store : chain_parameter * chain_storage) : operation list * chain_storage = 
@@ -12,6 +17,7 @@ let main (action, store : chain_parameter * chain_storage) : operation list * ch
         | None -> failwith "could not store"
         | Some c -> [] , c
         end
+    | Remove i -> [] , remove_batch (i, store)
 
 
 (* VIEWS *)

--- a/layer1/chain/src/chain_sc.mligo
+++ b/layer1/chain/src/chain_sc.mligo
@@ -1,41 +1,7 @@
-type hash = bytes
-type index = nat
-type batch = 
-    {  parent : index
-    ;  level : nat
-    ;  hash : hash
-    ;  proposer : address
-    }
-type chain_storage = 
-    {   max_index : nat
-    ;   batches : (index, batch) map
-    }
-
+#include "chain.mligo"
+type chain_storage = chain
 type chain_parameter = 
     | Receive of batch
-    
-let get_batch (index, store : index * chain_storage) : batch option = Map.find_opt index store.batches
-
-let is_batch_valid (batch, store : batch * chain_storage) : bool = 
-    batch.parent = 0n ||
-    ( let parent_opt = get_batch (batch.parent, store) in
-    match parent_opt with
-    | None -> false
-    | Some parent -> parent.level < batch.level )
-
-let store_batch (batch, store : batch * chain_storage) : chain_storage =
-    if is_batch_valid (batch,store) then
-        let new_index = store.max_index + 1n in
-        { store with 
-              batches = Map.update new_index (Some batch) store.batches 
-            ; max_index =  new_index
-        }
-    else failwith "could not store invalid batch"
-
-let get_latest_batch (store : chain_storage) : batch =
-    match get_batch (store.max_index, store) with
-    | None -> failwith "no batch"
-    | Some b -> b
 
 (* ENDPOINTS *)
 let main (action, store : chain_parameter * chain_storage) : operation list * chain_storage = 
@@ -45,4 +11,4 @@ let main (action, store : chain_parameter * chain_storage) : operation list * ch
 (* VIEWS *)
 
 [@view] let get_chain ((),s: unit * chain_storage) : chain_storage = s
-[@view] let get_latest ((),s: unit * chain_storage) : batch = get_latest_batch s
+[@view] let get_latest ((),s: unit * chain_storage) : batch option = find_latest_existing s

--- a/layer1/chain/src/chain_sc.mligo
+++ b/layer1/chain/src/chain_sc.mligo
@@ -5,7 +5,7 @@
 #include "chain.mligo"
 type chain_storage = chain
 type chain_parameter = 
-    | Receive of batch
+    | Receive of block
     | Remove  of index
 
 (* ENDPOINTS *)
@@ -13,14 +13,14 @@ let main (action, store : chain_parameter * chain_storage) : operation list * ch
     match action with
     | Receive b -> 
         begin 
-        match store_batch (b, store) with
+        match store_block (b, store) with
         | Error _ -> failwith "could not store"
         | Ok c -> [] , c
         end
-    | Remove i -> [] , remove_batch (i, store)
+    | Remove i -> [] , remove_block (i, store)
 
 
 (* VIEWS *)
 
 [@view] let get_chain ((),s: unit * chain_storage) : chain_storage = s
-[@view] let get_latest ((),s: unit * chain_storage) : batch option = find_latest_existing s
+[@view] let get_latest ((),s: unit * chain_storage) : block option = find_latest_existing s

--- a/layer1/chain/src/chain_sc.mligo
+++ b/layer1/chain/src/chain_sc.mligo
@@ -14,8 +14,8 @@ let main (action, store : chain_parameter * chain_storage) : operation list * ch
     | Receive b -> 
         begin 
         match store_batch (b, store) with
-        | None -> failwith "could not store"
-        | Some c -> [] , c
+        | Error _ -> failwith "could not store"
+        | Ok c -> [] , c
         end
     | Remove i -> [] , remove_batch (i, store)
 

--- a/layer1/chain/src/chain_sc.mligo
+++ b/layer1/chain/src/chain_sc.mligo
@@ -6,7 +6,13 @@ type chain_parameter =
 (* ENDPOINTS *)
 let main (action, store : chain_parameter * chain_storage) : operation list * chain_storage = 
     match action with
-    | Receive b -> [] , store_batch (b, store)
+    | Receive b -> 
+        begin 
+        match store_batch (b, store) with
+        | None -> failwith "could not store"
+        | Some c -> [] , c
+        end
+
 
 (* VIEWS *)
 

--- a/layer1/chain/src/chain_sc.mligo
+++ b/layer1/chain/src/chain_sc.mligo
@@ -6,7 +6,6 @@ type batch =
     ;  hash : hash
     ;  proposer : address
     }
-
 type chain_storage = 
     {   max_index : nat
     ;   batches : (index, batch) map
@@ -15,18 +14,26 @@ type chain_storage =
 type chain_parameter = 
     | Receive of batch
     
-let is_batch_valid (batch, store : batch * chain_storage) : bool = true
+let get_batch (index, store : index * chain_storage) : batch option = Map.find_opt index store.batches
+
+let is_batch_valid (batch, store : batch * chain_storage) : bool = 
+    batch.parent = 0n ||
+    ( let parent_opt = get_batch (batch.parent, store) in
+    match parent_opt with
+    | None -> false
+    | Some parent -> parent.level < batch.level )
 
 let store_batch (batch, store : batch * chain_storage) : chain_storage =
     if is_batch_valid (batch,store) then
-        {store with 
-              batches = Map.update store.max_index (Some batch) store.batches 
-            ; max_index = store.max_index + 1n 
+        let new_index = store.max_index + 1n in
+        { store with 
+              batches = Map.update new_index (Some batch) store.batches 
+            ; max_index =  new_index
         }
-    else store
+    else failwith "could not store invalid batch"
 
 let get_latest_batch (store : chain_storage) : batch =
-    match Map.find_opt store.max_index store.batches with
+    match get_batch (store.max_index, store) with
     | None -> failwith "no batch"
     | Some b -> b
 
@@ -34,6 +41,8 @@ let get_latest_batch (store : chain_storage) : batch =
 let main (action, store : chain_parameter * chain_storage) : operation list * chain_storage = 
     match action with
     | Receive b -> [] , store_batch (b, store)
+
+(* VIEWS *)
 
 [@view] let get_chain ((),s: unit * chain_storage) : chain_storage = s
 [@view] let get_latest ((),s: unit * chain_storage) : batch = get_latest_batch s

--- a/layer1/chain/test/suites.mligo
+++ b/layer1/chain/test/suites.mligo
@@ -1,0 +1,4 @@
+#import "test_chain_sc.mligo" "SC"
+#import "test_chain.mligo" "Lib"
+
+let suites = [SC.suite ; Lib.suite]

--- a/layer1/chain/test/test_chain.mligo
+++ b/layer1/chain/test/test_chain.mligo
@@ -78,6 +78,67 @@ let _test_remove_grand_child () =
     ;  Unit.assert_equals 1n new_chain.max_index "max_index did not change"
     ] 
 
+
+let _test_receive_first_block () = 
+    let first = batch 0n 10n in
+    let chain = empty_chain in
+    let new_chain = store_batch (first, chain) in
+    Unit.and_lazy_list 
+    [  fun () -> Unit.assert_not_none new_chain "store should have succeeded"
+    ;  fun () -> let new_chain = Option.unopt new_chain in Unit.assert_equals 1n (new_chain.max_index) "max_index should be 1"
+    ;  fun () -> let new_chain = Option.unopt new_chain in Unit.assert_equals (Some first) (get_batch (1n, new_chain)) "the batch should have been stored"
+    ]
+
+
+
+let _test_receive_son () = 
+    let first = batch 0n 10n in
+    let second = batch 1n 20n in
+    let chain = 
+    { max_index = 1n 
+    ; batches = (Big_map.literal [(1n,first)])
+    ; children = (Big_map.empty : (index, index list) big_map)
+    } in
+    let new_chain = store_batch (second, chain) in
+    Unit.and_lazy_list 
+    [  fun () -> Unit.assert_not_none new_chain "store should have succeeded"
+    ;  fun () -> let new_chain = Option.unopt new_chain in Unit.assert_equals 2n (new_chain.max_index) "max_index should be 2"
+    ;  fun () -> let new_chain = Option.unopt new_chain in Unit.assert_equals (Some first) (get_batch (1n, new_chain)) "the first batch should have been stored"
+    ;  fun () -> let new_chain = Option.unopt new_chain in Unit.assert_equals (Some second) (get_batch (2n, new_chain)) "the second batch should have been stored"
+    ;  fun () -> let new_chain = Option.unopt new_chain in Unit.assert_equals (Some [2n]) (get_children (1n, new_chain)) "second batch is a child of first"
+    ]
+
+let _test_receive_siblings () = 
+    let first = batch 0n 10n in
+    let second = batch 1n 20n in
+    let third = batch 1n 20n in
+    let chain = 
+    { max_index = 2n 
+    ; batches = (Big_map.literal [(1n, first) ; (2n, second)])
+    ; children = (Big_map.literal [(1n, [2n])])
+    } in
+    let new_chain = store_batch (third, chain) in
+    Unit.and_lazy_list 
+    [  fun () -> Unit.assert_not_none new_chain "store should have succeeded"
+    ;  fun () -> let new_chain = Option.unopt new_chain in Unit.assert_equals 3n (new_chain.max_index) "max_index should be 3"
+    ;  fun () -> let new_chain = Option.unopt new_chain in Unit.assert_equals (Some first) (get_batch (1n, new_chain)) "the first batch should have been stored"
+    ;  fun () -> let new_chain = Option.unopt new_chain in Unit.assert_equals (Some second) (get_batch (2n, new_chain)) "the second batch should have been stored"
+    ;  fun () -> let new_chain = Option.unopt new_chain in Unit.assert_equals (Some third) (get_batch (3n, new_chain)) "the third batch should have been stored"
+    ;  fun () -> let new_chain = Option.unopt new_chain in Unit.assert_equals (Some [3n ; 2n]) (get_children (1n, new_chain)) "second and third batch are children of first"
+    ]
+
+let _test_receive_orphan  () = 
+    let first = batch 0n 10n in
+    let second = batch 3n 20n in
+    let chain = 
+    { max_index = 1n 
+    ; batches = (Big_map.literal [(1n,first)])
+    ; children = (Big_map.empty : (index, index list) big_map)
+    } in
+    let new_chain = store_batch (second, chain) in
+    Unit.assert_equals (None : chain option) new_chain "store should have failed"
+
+
 (* Creation of test suite *)
 let suite = Unit.make_suite
 "Chain"
@@ -85,5 +146,9 @@ let suite = Unit.make_suite
 [  Unit.make_test "add one then delete" "test sending first block"  _test_remove_one           
 ;  Unit.make_test "add two" "sending a son, deleting the father" _test_remove_father            
 ;  Unit.make_test "add three: siblings" "sending two children for first block, deleting father" _test_remove_twins                   
-;  Unit.make_test "add three: grand-children" "one <- two <- three, delete one" _test_remove_grand_child           
+;  Unit.make_test "add three: grand-children" "one <- two <- three, delete one" _test_remove_grand_child 
+;  Unit.make_test "First block: success" "test sending first block"  _test_receive_first_block           
+;  Unit.make_test "Second block: success" "sending a son" _test_receive_son            
+;  Unit.make_test "Third block: success" "sending two children for first block" _test_receive_siblings                   
+;  Unit.make_test "Second block: failure" "sending an orphan" _test_receive_orphan           
 ]

--- a/layer1/chain/test/test_chain.mligo
+++ b/layer1/chain/test/test_chain.mligo
@@ -1,113 +1,89 @@
-#include "../src/chain_sc.mligo"
+#include "../src/chain.mligo"
 #import "../../stdlib_ext/src/unit_test.mligo" "Unit"
 
-(* UTILS *)
-type originated = Unit.originated // FIXME LIGO
-type originated_chain = (chain_parameter, chain_storage) originated
-let originate_chain () : originated_chain = 
-    let empty_storage : chain_storage = 
-        { max_index = 0n 
-        ; batches = (Map.empty : (index, batch) map)
-        } in
-    Unit.originate main empty_storage 0tez
-
-(* TESTS *)
 
 let _tbi () = Unit.fail_with "TBI"
+let empty_chain = 
+    { max_index = 0n 
+    ; batches = (Big_map.empty : (index, batch) big_map)
+    ; children = (Big_map.empty : (index, index list) big_map)
+    }
 
-// test sending a block
-let _test_receive_first_block () = 
-    let operator, actors = Unit.init_default () in 
-    let alice, _bob, _carol = actors in 
-    let chain : originated_chain = Unit.act_as operator originate_chain  in
-    let my_batch  = 
-        {  parent = 0n
-        ;  level = 0n
+let batch (parent:index) (level:nat) : batch = 
+        {  parent = parent
+        ;  level = level
         ;  hash = 0x0101
-        ;  proposer = alice.address
-        } in 
-    let send_block () = Unit.transfer_to_contract_ chain.originated_contract (Receive my_batch) 0tez in
-    let result = Unit.act_as alice send_block in
-    let storage = Test.get_storage chain.originated_typed_address in
+        ;  proposer = ("tz1gjaF81ZRRvdzjobyfVNsAeSC6PScjfQwN" : address)
+        }
+
+let _test_remove_one () = 
+    let first = batch 0n 0n in
+    let chain = 
+    { max_index = 1n 
+    ; batches = Big_map.literal [(1n, first)]
+    ; children = (Big_map.empty : (index, index list) big_map)
+    } in
+    let new_chain = remove_batch (1n, chain) in
     Unit.and_list 
-    [  result 
-    ;  Unit.assert_equals 1n (storage.max_index) "max_index should be 1"
-    ;  Unit.assert_equals (Some my_batch) (get_batch (1n, storage)) "the batch should have been stored"
-    ]
+    [  Unit.assert_equals (None : batch option) (Big_map.find_opt 1n new_chain.batches) "batch should not be stored anymore"
+    ;  Unit.assert_equals 1n new_chain.max_index "max_index did not change"
+    ] 
 
-
-// test sending its son
-let _test_receive_son () = 
-    // setup
-    let operator, actors = Unit.init_default () in 
-    let alice, bob, _carol = actors in 
-    let chain : originated_chain = Unit.act_as operator originate_chain  in
-
-    // act
-    let first_batch  = 
-        {  parent = 0n
-        ;  level = 0n
-        ;  hash = 0x0101
-        ;  proposer = alice.address
-        } in 
-    let second_batch = 
-        {  parent = 1n
-        ;  level = 10n
-        ;  hash = 0x0101
-        ;  proposer = bob.address
-        } in 
-    let send_block (batch : batch) () = Unit.transfer_to_contract_ chain.originated_contract (Receive batch) 0tez in
-    let result_alice = Unit.act_as alice (send_block first_batch) in
-    let result_bob = Unit.act_as bob (send_block second_batch) in
-
-    // assert
-    let storage = Test.get_storage chain.originated_typed_address in
+let _test_remove_father () =
+    let first = batch 0n 0n in
+    let second = batch 1n 0n in
+    let chain = 
+    { max_index = 1n 
+    ; batches = Big_map.literal [(1n, first) ; (2n, second)]
+    ; children = Big_map.literal [(1n, [2n])]
+    } in
+    let new_chain = remove_batch (1n, chain) in
     Unit.and_list 
-    [  Unit.assert_is_ok result_alice "first batch should have succeeded"
-    ;  Unit.assert_is_ok result_bob  "second batch should have succeeded"
-    ;  Unit.assert_equals 2n (storage.max_index) "max_index should be 2"
-    ;  Unit.assert_equals (Some first_batch) (get_batch (1n, storage)) "the first batch should have been stored"
-    ;  Unit.assert_equals (Some second_batch) (get_batch (2n, storage)) "the second batch should have been stored"
-    ]
+    [  Unit.assert_equals (None : batch option) (Big_map.find_opt 1n new_chain.batches) "batch 1 should not be stored anymore"
+    ;  Unit.assert_equals (None : batch option) (Big_map.find_opt 2n new_chain.batches) "batch 2 should not be stored anymore"
+    ;  Unit.assert_equals 1n new_chain.max_index "max_index did not change"
+    ] 
 
-// test sending an orphan
-let _test_receive_orphan () = 
-    // setup
-    let operator, actors = Unit.init_default () in 
-    let alice, bob, _carol = actors in 
-    let chain : originated_chain = Unit.act_as operator originate_chain  in
-    
-    // act
-    let first_batch  = 
-        {  parent = 0n
-        ;  level = 0n
-        ;  hash = 0x0101
-        ;  proposer = alice.address
-        } in 
-    let second_batch = 
-        {  parent = 3n
-        ;  level = 10n
-        ;  hash = 0x0101
-        ;  proposer = bob.address
-        } in 
-    let send_block (batch : batch) () = Unit.transfer_to_contract_ chain.originated_contract (Receive batch) 0tez in
-    let result_alice = Unit.act_as alice (send_block first_batch) in
-    let result_bob = Unit.act_as bob (send_block second_batch) in
-
-    // assert
-    let storage = Test.get_storage chain.originated_typed_address in
+let _test_remove_twins () =
+    let first = batch 0n 0n in
+    let second = batch 1n 0n in
+    let third = batch 1n 0n in
+    let chain = 
+    { max_index = 1n 
+    ; batches = Big_map.literal [(1n, first) ; (2n, second) ; (3n, third)]
+    ; children = Big_map.literal [(1n, [3n;2n])]
+    } in
+    let new_chain = remove_batch (1n, chain) in
     Unit.and_list 
-    [  Unit.assert_is_ok result_alice "first batch should have succeeded"
-    ;  Unit.assert_rejected result_bob  "second batch should have failed"
-    ;  Unit.assert_equals 1n (storage.max_index) "max_index should be 1: the second batch failed"
-    ;  Unit.assert_equals (Some first_batch) (get_batch (1n, storage)) "the batch should have been stored"
-    ]
+    [  Unit.assert_equals (None : batch option) (Big_map.find_opt 1n new_chain.batches) "batch 1 should not be stored anymore"
+    ;  Unit.assert_equals (None : batch option) (Big_map.find_opt 2n new_chain.batches) "batch 2 should not be stored anymore"
+    ;  Unit.assert_equals (None : batch option) (Big_map.find_opt 3n new_chain.batches) "batch 3 should not be stored anymore"
+    ;  Unit.assert_equals 1n new_chain.max_index "max_index did not change"
+    ] 
+
+let _test_remove_grand_child () =
+    let first = batch 0n 0n in
+    let second = batch 1n 0n in
+    let third = batch 2n 0n in
+    let chain = 
+    { max_index = 1n 
+    ; batches = Big_map.literal [(1n, first) ; (2n, second) ; (3n, third)]
+    ; children = Big_map.literal [(1n, [2n]) ; (2n, [3n])]
+    } in
+    let new_chain = remove_batch (1n, chain) in
+    Unit.and_list 
+    [  Unit.assert_equals (None : batch option) (Big_map.find_opt 1n new_chain.batches) "batch 1 should not be stored anymore"
+    ;  Unit.assert_equals (None : batch option) (Big_map.find_opt 2n new_chain.batches) "batch 2 should not be stored anymore"
+    ;  Unit.assert_equals (None : batch option) (Big_map.find_opt 3n new_chain.batches) "batch 3 should not be stored anymore"
+    ;  Unit.assert_equals 1n new_chain.max_index "max_index did not change"
+    ] 
 
 (* Creation of test suite *)
 let suite = Unit.make_suite
-"Chain_sc"
-"Test suite of bridge storage of batches"
-[  Unit.make_test "First block: success" "test sending first block"  _test_receive_first_block           
-;  Unit.make_test "Second block: success" "sending a son" _test_receive_son                   
-;  Unit.make_test "Second block: failure" "sending an orphan" _test_receive_orphan           
+"Chain"
+"Test suite of batch storage lib"
+[  Unit.make_test "add one then delete" "test sending first block"  _test_remove_one           
+;  Unit.make_test "add two" "sending a son, deleting the father" _test_remove_father            
+;  Unit.make_test "add three: siblings" "sending two children for first block, deleting father" _test_remove_twins                   
+;  Unit.make_test "add three: grand-children" "one <- two <- three, delete one" _test_remove_grand_child           
 ]

--- a/layer1/chain/test/test_chain.mligo
+++ b/layer1/chain/test/test_chain.mligo
@@ -2,7 +2,6 @@
 #import "../../stdlib_ext/src/unit_test.mligo" "Unit"
 
 
-let _tbi () = Unit.fail_with "TBI"
 let empty_chain = 
     { max_index = 0n 
     ; batches = (Big_map.empty : (index, batch) big_map)

--- a/layer1/chain/test/test_chain.mligo
+++ b/layer1/chain/test/test_chain.mligo
@@ -5,11 +5,11 @@
 
 let empty_chain : chain = 
     { max_index = 0n 
-    ; batches = (Big_map.empty : (index, batch) big_map)
+    ; blocks = (Big_map.empty : (index, block) big_map)
     ; children = (Big_map.empty : (index, index list) big_map)
     }
 
-let batch (parent:index) (level:nat) : batch = 
+let block (parent:index) (level:nat) : block = 
         {  parent = parent
         ;  level = level
         ;  hash = 0x0101
@@ -17,139 +17,139 @@ let batch (parent:index) (level:nat) : batch =
         }
 
 let _test_remove_one () = 
-    let first = batch 0n 0n in
+    let first = block 0n 0n in
     let chain = 
     { empty_chain with
       max_index = 1n 
-    ; batches = Big_map.literal [(1n, first)]
+    ; blocks = Big_map.literal [(1n, first)]
     ; children = (Big_map.empty : (index, index list) big_map)
     } in
-    let new_chain = remove_batch (1n, chain) in
+    let new_chain = remove_block (1n, chain) in
     Unit.and_list 
-    [  Unit.assert_equals (None : batch option) (Big_map.find_opt 1n new_chain.batches) "batch should not be stored anymore"
+    [  Unit.assert_equals (None : block option) (Big_map.find_opt 1n new_chain.blocks) "block should not be stored anymore"
     ;  Unit.assert_equals 1n new_chain.max_index "max_index did not change"
     ] 
 
 let _test_remove_father () =
-    let first = batch 0n 0n in
-    let second = batch 1n 0n in
+    let first = block 0n 0n in
+    let second = block 1n 0n in
     let chain = 
     { empty_chain with
       max_index = 1n 
-    ; batches = Big_map.literal [(1n, first) ; (2n, second)]
+    ; blocks = Big_map.literal [(1n, first) ; (2n, second)]
     ; children = Big_map.literal [(1n, [2n])]
     } in
-    let new_chain = remove_batch (1n, chain) in
+    let new_chain = remove_block (1n, chain) in
     Unit.and_list 
-    [  Unit.assert_equals (None : batch option) (Big_map.find_opt 1n new_chain.batches) "batch 1 should not be stored anymore"
-    ;  Unit.assert_equals (None : batch option) (Big_map.find_opt 2n new_chain.batches) "batch 2 should not be stored anymore"
+    [  Unit.assert_equals (None : block option) (Big_map.find_opt 1n new_chain.blocks) "block 1 should not be stored anymore"
+    ;  Unit.assert_equals (None : block option) (Big_map.find_opt 2n new_chain.blocks) "block 2 should not be stored anymore"
     ;  Unit.assert_equals 1n new_chain.max_index "max_index did not change"
     ] 
 
 let _test_remove_twins () =
-    let first = batch 0n 0n in
-    let second = batch 1n 0n in
-    let third = batch 1n 0n in
+    let first = block 0n 0n in
+    let second = block 1n 0n in
+    let third = block 1n 0n in
     let chain = 
     { empty_chain with
       max_index = 1n 
-    ; batches = Big_map.literal [(1n, first) ; (2n, second) ; (3n, third)]
+    ; blocks = Big_map.literal [(1n, first) ; (2n, second) ; (3n, third)]
     ; children = Big_map.literal [(1n, [3n;2n])]
     } in
-    let new_chain = remove_batch (1n, chain) in
+    let new_chain = remove_block (1n, chain) in
     Unit.and_list 
-    [  Unit.assert_equals (None : batch option) (Big_map.find_opt 1n new_chain.batches) "batch 1 should not be stored anymore"
-    ;  Unit.assert_equals (None : batch option) (Big_map.find_opt 2n new_chain.batches) "batch 2 should not be stored anymore"
-    ;  Unit.assert_equals (None : batch option) (Big_map.find_opt 3n new_chain.batches) "batch 3 should not be stored anymore"
+    [  Unit.assert_equals (None : block option) (Big_map.find_opt 1n new_chain.blocks) "block 1 should not be stored anymore"
+    ;  Unit.assert_equals (None : block option) (Big_map.find_opt 2n new_chain.blocks) "block 2 should not be stored anymore"
+    ;  Unit.assert_equals (None : block option) (Big_map.find_opt 3n new_chain.blocks) "block 3 should not be stored anymore"
     ;  Unit.assert_equals 1n new_chain.max_index "max_index did not change"
     ] 
 
 let _test_remove_grand_child () =
-    let first = batch 0n 0n in
-    let second = batch 1n 0n in
-    let third = batch 2n 0n in
+    let first = block 0n 0n in
+    let second = block 1n 0n in
+    let third = block 2n 0n in
     let chain = 
     { empty_chain with
       max_index = 1n 
-    ; batches = Big_map.literal [(1n, first) ; (2n, second) ; (3n, third)]
+    ; blocks = Big_map.literal [(1n, first) ; (2n, second) ; (3n, third)]
     ; children = Big_map.literal [(1n, [2n]) ; (2n, [3n])]
     } in
-    let new_chain = remove_batch (1n, chain) in
+    let new_chain = remove_block (1n, chain) in
     Unit.and_list 
-    [  Unit.assert_equals (None : batch option) (Big_map.find_opt 1n new_chain.batches) "batch 1 should not be stored anymore"
-    ;  Unit.assert_equals (None : batch option) (Big_map.find_opt 2n new_chain.batches) "batch 2 should not be stored anymore"
-    ;  Unit.assert_equals (None : batch option) (Big_map.find_opt 3n new_chain.batches) "batch 3 should not be stored anymore"
+    [  Unit.assert_equals (None : block option) (Big_map.find_opt 1n new_chain.blocks) "block 1 should not be stored anymore"
+    ;  Unit.assert_equals (None : block option) (Big_map.find_opt 2n new_chain.blocks) "block 2 should not be stored anymore"
+    ;  Unit.assert_equals (None : block option) (Big_map.find_opt 3n new_chain.blocks) "block 3 should not be stored anymore"
     ;  Unit.assert_equals 1n new_chain.max_index "max_index did not change"
     ] 
 
 
 let _test_receive_first_block () = 
-    let first = batch 0n 10n in
+    let first = block 0n 10n in
     let chain = empty_chain in
-    let new_chain = store_batch (first, chain) in
+    let new_chain = store_block (first, chain) in
     Unit.and_lazy_list 
     [  fun () -> Unit.assert_ (Stdlib_Result.is_ok new_chain) "store should have succeeded"
     ;  fun () -> let new_chain = Stdlib_Result.get_ok new_chain in Unit.assert_equals 1n (new_chain.max_index) "max_index should be 1"
-    ;  fun () -> let new_chain = Stdlib_Result.get_ok new_chain in Unit.assert_equals (Some first) (get_batch (1n, new_chain)) "the batch should have been stored"
+    ;  fun () -> let new_chain = Stdlib_Result.get_ok new_chain in Unit.assert_equals (Some first) (get_block (1n, new_chain)) "the block should have been stored"
     ]
 
 
 
 let _test_receive_son () = 
-    let first = batch 0n 10n in
-    let second = batch 1n 20n in
+    let first = block 0n 10n in
+    let second = block 1n 20n in
     let chain = 
     { empty_chain with
       max_index = 1n 
-    ; batches = (Big_map.literal [(1n,first)])
+    ; blocks = (Big_map.literal [(1n,first)])
     ; children = (Big_map.empty : (index, index list) big_map)
     } in
-    let new_chain = store_batch (second, chain) in
+    let new_chain = store_block (second, chain) in
     Unit.and_lazy_list 
     [  fun () -> Unit.assert_ (Stdlib_Result.is_ok new_chain) "store should have succeeded"
     ;  fun () -> let new_chain = Stdlib_Result.get_ok new_chain in Unit.assert_equals 2n (new_chain.max_index) "max_index should be 2"
-    ;  fun () -> let new_chain = Stdlib_Result.get_ok new_chain in Unit.assert_equals (Some first) (get_batch (1n, new_chain)) "the first batch should have been stored"
-    ;  fun () -> let new_chain = Stdlib_Result.get_ok new_chain in Unit.assert_equals (Some second) (get_batch (2n, new_chain)) "the second batch should have been stored"
-    ;  fun () -> let new_chain = Stdlib_Result.get_ok new_chain in Unit.assert_equals (Some [2n]) (get_children (1n, new_chain)) "second batch is a child of first"
+    ;  fun () -> let new_chain = Stdlib_Result.get_ok new_chain in Unit.assert_equals (Some first) (get_block (1n, new_chain)) "the first block should have been stored"
+    ;  fun () -> let new_chain = Stdlib_Result.get_ok new_chain in Unit.assert_equals (Some second) (get_block (2n, new_chain)) "the second block should have been stored"
+    ;  fun () -> let new_chain = Stdlib_Result.get_ok new_chain in Unit.assert_equals (Some [2n]) (get_children (1n, new_chain)) "second block is a child of first"
     ]
 
 let _test_receive_siblings () = 
-    let first = batch 0n 10n in
-    let second = batch 1n 20n in
-    let third = batch 1n 20n in
+    let first = block 0n 10n in
+    let second = block 1n 20n in
+    let third = block 1n 20n in
     let chain = 
     { empty_chain with
       max_index = 2n 
-    ; batches = (Big_map.literal [(1n, first) ; (2n, second)])
+    ; blocks = (Big_map.literal [(1n, first) ; (2n, second)])
     ; children = (Big_map.literal [(1n, [2n])])
     } in
-    let new_chain = store_batch (third, chain) in
+    let new_chain = store_block (third, chain) in
     Unit.and_lazy_list 
     [  fun () -> Unit.assert_ (Stdlib_Result.is_ok new_chain) "store should have succeeded"
     ;  fun () -> let new_chain = Stdlib_Result.get_ok new_chain in Unit.assert_equals 3n (new_chain.max_index) "max_index should be 3"
-    ;  fun () -> let new_chain = Stdlib_Result.get_ok new_chain in Unit.assert_equals (Some first) (get_batch (1n, new_chain)) "the first batch should have been stored"
-    ;  fun () -> let new_chain = Stdlib_Result.get_ok new_chain in Unit.assert_equals (Some second) (get_batch (2n, new_chain)) "the second batch should have been stored"
-    ;  fun () -> let new_chain = Stdlib_Result.get_ok new_chain in Unit.assert_equals (Some third) (get_batch (3n, new_chain)) "the third batch should have been stored"
-    ;  fun () -> let new_chain = Stdlib_Result.get_ok new_chain in Unit.assert_equals (Some [3n ; 2n]) (get_children (1n, new_chain)) "second and third batch are children of first"
+    ;  fun () -> let new_chain = Stdlib_Result.get_ok new_chain in Unit.assert_equals (Some first) (get_block (1n, new_chain)) "the first block should have been stored"
+    ;  fun () -> let new_chain = Stdlib_Result.get_ok new_chain in Unit.assert_equals (Some second) (get_block (2n, new_chain)) "the second block should have been stored"
+    ;  fun () -> let new_chain = Stdlib_Result.get_ok new_chain in Unit.assert_equals (Some third) (get_block (3n, new_chain)) "the third block should have been stored"
+    ;  fun () -> let new_chain = Stdlib_Result.get_ok new_chain in Unit.assert_equals (Some [3n ; 2n]) (get_children (1n, new_chain)) "second and third block are children of first"
     ]
 
 let _test_receive_orphan  () = 
-    let first = batch 0n 10n in
-    let second = batch 3n 20n in
+    let first = block 0n 10n in
+    let second = block 3n 20n in
     let chain = 
     { empty_chain with
       max_index = 1n 
-    ; batches = (Big_map.literal [(1n,first)])
+    ; blocks = (Big_map.literal [(1n,first)])
     ; children = (Big_map.empty : (index, index list) big_map)
     } in
-    let new_chain = store_batch (second, chain) in
+    let new_chain = store_block (second, chain) in
     Unit.assert_ (Stdlib_Result.is_error new_chain)  "store should have failed"
 
 
 (* Creation of test suite *)
 let suite = Unit.make_suite
 "Chain"
-"Test suite of batch storage lib"
+"Test suite of block storage lib"
 [  Unit.make_test "add one then delete" "test sending first block"  _test_remove_one           
 ;  Unit.make_test "add two" "sending a son, deleting the father" _test_remove_father            
 ;  Unit.make_test "add three: siblings" "sending two children for first block, deleting father" _test_remove_twins                   

--- a/layer1/chain/test/test_chain.mligo
+++ b/layer1/chain/test/test_chain.mligo
@@ -15,6 +15,13 @@ let block (parent:index) (level:nat) : block =
         ;  hash = 0x0101
         ;  proposer = ("tz1gjaF81ZRRvdzjobyfVNsAeSC6PScjfQwN" : address)
         }
+        
+let _test_remove_none () =
+    let new_chain = remove_block (1n, empty_chain) in
+    Unit.and_list 
+    [  Unit.assert_equals (None : block option) (Big_map.find_opt 1n new_chain.blocks) "block should not be stored anymore"
+    ;  Unit.assert_equals 0n new_chain.max_index "max_index did not change"
+    ] 
 
 let _test_remove_one () = 
     let first = block 0n 0n in
@@ -46,7 +53,23 @@ let _test_remove_father () =
     ;  Unit.assert_equals 1n new_chain.max_index "max_index did not change"
     ] 
 
-let _test_remove_twins () =
+let _test_remove_child () =
+    let first = block 0n 0n in
+    let second = block 1n 0n in
+    let chain = 
+    { empty_chain with
+      max_index = 1n 
+    ; blocks = Big_map.literal [(1n, first) ; (2n, second)]
+    ; children = Big_map.literal [(1n, [2n])]
+    } in
+    let new_chain = remove_block (2n, chain) in
+    Unit.and_list 
+    [  Unit.assert_equals (None : block option) (Big_map.find_opt 2n new_chain.blocks) "block 2 should not be stored anymore"
+    ;  Unit.assert_equals (Some first) (Big_map.find_opt 1n new_chain.blocks) "the block should have been stored"
+    ;  Unit.assert_equals 1n new_chain.max_index "max_index did not change"
+    ] 
+
+let _test_twins_are_correctly_removed () =
     let first = block 0n 0n in
     let second = block 1n 0n in
     let third = block 1n 0n in
@@ -64,7 +87,7 @@ let _test_remove_twins () =
     ;  Unit.assert_equals 1n new_chain.max_index "max_index did not change"
     ] 
 
-let _test_remove_grand_child () =
+let _test_grand_child_is_correcty_removed () =
     let first = block 0n 0n in
     let second = block 1n 0n in
     let third = block 2n 0n in
@@ -150,12 +173,14 @@ let _test_receive_orphan  () =
 let suite = Unit.make_suite
 "Chain"
 "Test suite of block storage lib"
-[  Unit.make_test "add one then delete" "test sending first block"  _test_remove_one           
-;  Unit.make_test "add two" "sending a son, deleting the father" _test_remove_father            
-;  Unit.make_test "add three: siblings" "sending two children for first block, deleting father" _test_remove_twins                   
-;  Unit.make_test "add three: grand-children" "one <- two <- three, delete one" _test_remove_grand_child 
+[  Unit.make_test "remove no block" "test deleting when there is no block"  _test_remove_none           
+;  Unit.make_test "remove first block" "test sending then deleting first block"  _test_remove_one           
+;  Unit.make_test "remove a parent" "sending a son, deleting the father, checking son is removed" _test_remove_father            
+;  Unit.make_test "remove a parent of two" "sending two children for first block, deleting father, checking children are removed" _test_twins_are_correctly_removed                   
+;  Unit.make_test "remove grand-parent" "one <- two <- three, delete one, check that child and grand-child are removed" _test_grand_child_is_correcty_removed 
+;  Unit.make_test "remove child" "removing a child" _test_remove_child
 ;  Unit.make_test "First block: success" "test sending first block"  _test_receive_first_block           
 ;  Unit.make_test "Second block: success" "sending a son" _test_receive_son            
 ;  Unit.make_test "Third block: success" "sending two children for first block" _test_receive_siblings                   
-;  Unit.make_test "Second block: failure" "sending an orphan" _test_receive_orphan           
+;  Unit.make_test "Second block: failure" "sending an orphan" _test_receive_orphan
 ]

--- a/layer1/chain/test/test_chain.mligo
+++ b/layer1/chain/test/test_chain.mligo
@@ -7,6 +7,7 @@ let empty_chain =
     { max_index = 0n 
     ; batches = (Big_map.empty : (index, batch) big_map)
     ; children = (Big_map.empty : (index, index list) big_map)
+    ; latest_finalized = 0n
     }
 
 let batch (parent:index) (level:nat) : batch = 
@@ -19,7 +20,8 @@ let batch (parent:index) (level:nat) : batch =
 let _test_remove_one () = 
     let first = batch 0n 0n in
     let chain = 
-    { max_index = 1n 
+    { empty_chain with
+      max_index = 1n 
     ; batches = Big_map.literal [(1n, first)]
     ; children = (Big_map.empty : (index, index list) big_map)
     } in
@@ -33,7 +35,8 @@ let _test_remove_father () =
     let first = batch 0n 0n in
     let second = batch 1n 0n in
     let chain = 
-    { max_index = 1n 
+    { empty_chain with
+      max_index = 1n 
     ; batches = Big_map.literal [(1n, first) ; (2n, second)]
     ; children = Big_map.literal [(1n, [2n])]
     } in
@@ -49,7 +52,8 @@ let _test_remove_twins () =
     let second = batch 1n 0n in
     let third = batch 1n 0n in
     let chain = 
-    { max_index = 1n 
+    { empty_chain with
+      max_index = 1n 
     ; batches = Big_map.literal [(1n, first) ; (2n, second) ; (3n, third)]
     ; children = Big_map.literal [(1n, [3n;2n])]
     } in
@@ -66,7 +70,8 @@ let _test_remove_grand_child () =
     let second = batch 1n 0n in
     let third = batch 2n 0n in
     let chain = 
-    { max_index = 1n 
+    { empty_chain with
+      max_index = 1n 
     ; batches = Big_map.literal [(1n, first) ; (2n, second) ; (3n, third)]
     ; children = Big_map.literal [(1n, [2n]) ; (2n, [3n])]
     } in
@@ -95,7 +100,8 @@ let _test_receive_son () =
     let first = batch 0n 10n in
     let second = batch 1n 20n in
     let chain = 
-    { max_index = 1n 
+    { empty_chain with
+      max_index = 1n 
     ; batches = (Big_map.literal [(1n,first)])
     ; children = (Big_map.empty : (index, index list) big_map)
     } in
@@ -113,7 +119,8 @@ let _test_receive_siblings () =
     let second = batch 1n 20n in
     let third = batch 1n 20n in
     let chain = 
-    { max_index = 2n 
+    { empty_chain with
+      max_index = 2n 
     ; batches = (Big_map.literal [(1n, first) ; (2n, second)])
     ; children = (Big_map.literal [(1n, [2n])])
     } in
@@ -131,7 +138,8 @@ let _test_receive_orphan  () =
     let first = batch 0n 10n in
     let second = batch 3n 20n in
     let chain = 
-    { max_index = 1n 
+    { empty_chain with
+      max_index = 1n 
     ; batches = (Big_map.literal [(1n,first)])
     ; children = (Big_map.empty : (index, index list) big_map)
     } in

--- a/layer1/chain/test/test_chain.mligo
+++ b/layer1/chain/test/test_chain.mligo
@@ -1,12 +1,12 @@
 #include "../src/chain.mligo"
 #import "../../stdlib_ext/src/unit_test.mligo" "Unit"
+#import "../../stdlib_ext/src/result.mligo" "Stdlib_Result"
 
 
-let empty_chain = 
+let empty_chain : chain = 
     { max_index = 0n 
     ; batches = (Big_map.empty : (index, batch) big_map)
     ; children = (Big_map.empty : (index, index list) big_map)
-    ; latest_finalized = 0n
     }
 
 let batch (parent:index) (level:nat) : batch = 
@@ -88,9 +88,9 @@ let _test_receive_first_block () =
     let chain = empty_chain in
     let new_chain = store_batch (first, chain) in
     Unit.and_lazy_list 
-    [  fun () -> Unit.assert_not_none new_chain "store should have succeeded"
-    ;  fun () -> let new_chain = Option.unopt new_chain in Unit.assert_equals 1n (new_chain.max_index) "max_index should be 1"
-    ;  fun () -> let new_chain = Option.unopt new_chain in Unit.assert_equals (Some first) (get_batch (1n, new_chain)) "the batch should have been stored"
+    [  fun () -> Unit.assert_ (Stdlib_Result.is_ok new_chain) "store should have succeeded"
+    ;  fun () -> let new_chain = Stdlib_Result.get_ok new_chain in Unit.assert_equals 1n (new_chain.max_index) "max_index should be 1"
+    ;  fun () -> let new_chain = Stdlib_Result.get_ok new_chain in Unit.assert_equals (Some first) (get_batch (1n, new_chain)) "the batch should have been stored"
     ]
 
 
@@ -106,11 +106,11 @@ let _test_receive_son () =
     } in
     let new_chain = store_batch (second, chain) in
     Unit.and_lazy_list 
-    [  fun () -> Unit.assert_not_none new_chain "store should have succeeded"
-    ;  fun () -> let new_chain = Option.unopt new_chain in Unit.assert_equals 2n (new_chain.max_index) "max_index should be 2"
-    ;  fun () -> let new_chain = Option.unopt new_chain in Unit.assert_equals (Some first) (get_batch (1n, new_chain)) "the first batch should have been stored"
-    ;  fun () -> let new_chain = Option.unopt new_chain in Unit.assert_equals (Some second) (get_batch (2n, new_chain)) "the second batch should have been stored"
-    ;  fun () -> let new_chain = Option.unopt new_chain in Unit.assert_equals (Some [2n]) (get_children (1n, new_chain)) "second batch is a child of first"
+    [  fun () -> Unit.assert_ (Stdlib_Result.is_ok new_chain) "store should have succeeded"
+    ;  fun () -> let new_chain = Stdlib_Result.get_ok new_chain in Unit.assert_equals 2n (new_chain.max_index) "max_index should be 2"
+    ;  fun () -> let new_chain = Stdlib_Result.get_ok new_chain in Unit.assert_equals (Some first) (get_batch (1n, new_chain)) "the first batch should have been stored"
+    ;  fun () -> let new_chain = Stdlib_Result.get_ok new_chain in Unit.assert_equals (Some second) (get_batch (2n, new_chain)) "the second batch should have been stored"
+    ;  fun () -> let new_chain = Stdlib_Result.get_ok new_chain in Unit.assert_equals (Some [2n]) (get_children (1n, new_chain)) "second batch is a child of first"
     ]
 
 let _test_receive_siblings () = 
@@ -125,12 +125,12 @@ let _test_receive_siblings () =
     } in
     let new_chain = store_batch (third, chain) in
     Unit.and_lazy_list 
-    [  fun () -> Unit.assert_not_none new_chain "store should have succeeded"
-    ;  fun () -> let new_chain = Option.unopt new_chain in Unit.assert_equals 3n (new_chain.max_index) "max_index should be 3"
-    ;  fun () -> let new_chain = Option.unopt new_chain in Unit.assert_equals (Some first) (get_batch (1n, new_chain)) "the first batch should have been stored"
-    ;  fun () -> let new_chain = Option.unopt new_chain in Unit.assert_equals (Some second) (get_batch (2n, new_chain)) "the second batch should have been stored"
-    ;  fun () -> let new_chain = Option.unopt new_chain in Unit.assert_equals (Some third) (get_batch (3n, new_chain)) "the third batch should have been stored"
-    ;  fun () -> let new_chain = Option.unopt new_chain in Unit.assert_equals (Some [3n ; 2n]) (get_children (1n, new_chain)) "second and third batch are children of first"
+    [  fun () -> Unit.assert_ (Stdlib_Result.is_ok new_chain) "store should have succeeded"
+    ;  fun () -> let new_chain = Stdlib_Result.get_ok new_chain in Unit.assert_equals 3n (new_chain.max_index) "max_index should be 3"
+    ;  fun () -> let new_chain = Stdlib_Result.get_ok new_chain in Unit.assert_equals (Some first) (get_batch (1n, new_chain)) "the first batch should have been stored"
+    ;  fun () -> let new_chain = Stdlib_Result.get_ok new_chain in Unit.assert_equals (Some second) (get_batch (2n, new_chain)) "the second batch should have been stored"
+    ;  fun () -> let new_chain = Stdlib_Result.get_ok new_chain in Unit.assert_equals (Some third) (get_batch (3n, new_chain)) "the third batch should have been stored"
+    ;  fun () -> let new_chain = Stdlib_Result.get_ok new_chain in Unit.assert_equals (Some [3n ; 2n]) (get_children (1n, new_chain)) "second and third batch are children of first"
     ]
 
 let _test_receive_orphan  () = 
@@ -143,7 +143,7 @@ let _test_receive_orphan  () =
     ; children = (Big_map.empty : (index, index list) big_map)
     } in
     let new_chain = store_batch (second, chain) in
-    Unit.assert_equals (None : chain option) new_chain "store should have failed"
+    Unit.assert_ (Stdlib_Result.is_error new_chain)  "store should have failed"
 
 
 (* Creation of test suite *)

--- a/layer1/chain/test/test_chain.mligo
+++ b/layer1/chain/test/test_chain.mligo
@@ -1,0 +1,113 @@
+#include "../src/chain_sc.mligo"
+#import "../../stdlib_ext/src/unit_test.mligo" "Unit"
+
+(* UTILS *)
+type originated = Unit.originated // FIXME LIGO
+type originated_chain = (chain_parameter, chain_storage) originated
+let originate_chain () : originated_chain = 
+    let empty_storage : chain_storage = 
+        { max_index = 0n 
+        ; batches = (Map.empty : (index, batch) map)
+        } in
+    Unit.originate main empty_storage 0tez
+
+(* TESTS *)
+
+let _tbi () = Unit.fail_with "TBI"
+
+// test sending a block
+let _test_receive_first_block () = 
+    let operator, actors = Unit.init_default () in 
+    let alice, _bob, _carol = actors in 
+    let chain : originated_chain = Unit.act_as operator originate_chain  in
+    let my_batch  = 
+        {  parent = 0n
+        ;  level = 0n
+        ;  hash = 0x0101
+        ;  proposer = alice.address
+        } in 
+    let send_block () = Unit.transfer_to_contract_ chain.originated_contract (Receive my_batch) 0tez in
+    let result = Unit.act_as alice send_block in
+    let storage = Test.get_storage chain.originated_typed_address in
+    Unit.and_list 
+    [  result 
+    ;  Unit.assert_equals 1n (storage.max_index) "max_index should be 1"
+    ;  Unit.assert_equals (Some my_batch) (get_batch (1n, storage)) "the batch should have been stored"
+    ]
+
+
+// test sending its son
+let _test_receive_son () = 
+    // setup
+    let operator, actors = Unit.init_default () in 
+    let alice, bob, _carol = actors in 
+    let chain : originated_chain = Unit.act_as operator originate_chain  in
+
+    // act
+    let first_batch  = 
+        {  parent = 0n
+        ;  level = 0n
+        ;  hash = 0x0101
+        ;  proposer = alice.address
+        } in 
+    let second_batch = 
+        {  parent = 1n
+        ;  level = 10n
+        ;  hash = 0x0101
+        ;  proposer = bob.address
+        } in 
+    let send_block (batch : batch) () = Unit.transfer_to_contract_ chain.originated_contract (Receive batch) 0tez in
+    let result_alice = Unit.act_as alice (send_block first_batch) in
+    let result_bob = Unit.act_as bob (send_block second_batch) in
+
+    // assert
+    let storage = Test.get_storage chain.originated_typed_address in
+    Unit.and_list 
+    [  Unit.assert_is_ok result_alice "first batch should have succeeded"
+    ;  Unit.assert_is_ok result_bob  "second batch should have succeeded"
+    ;  Unit.assert_equals 2n (storage.max_index) "max_index should be 2"
+    ;  Unit.assert_equals (Some first_batch) (get_batch (1n, storage)) "the first batch should have been stored"
+    ;  Unit.assert_equals (Some second_batch) (get_batch (2n, storage)) "the second batch should have been stored"
+    ]
+
+// test sending an orphan
+let _test_receive_orphan () = 
+    // setup
+    let operator, actors = Unit.init_default () in 
+    let alice, bob, _carol = actors in 
+    let chain : originated_chain = Unit.act_as operator originate_chain  in
+    
+    // act
+    let first_batch  = 
+        {  parent = 0n
+        ;  level = 0n
+        ;  hash = 0x0101
+        ;  proposer = alice.address
+        } in 
+    let second_batch = 
+        {  parent = 3n
+        ;  level = 10n
+        ;  hash = 0x0101
+        ;  proposer = bob.address
+        } in 
+    let send_block (batch : batch) () = Unit.transfer_to_contract_ chain.originated_contract (Receive batch) 0tez in
+    let result_alice = Unit.act_as alice (send_block first_batch) in
+    let result_bob = Unit.act_as bob (send_block second_batch) in
+
+    // assert
+    let storage = Test.get_storage chain.originated_typed_address in
+    Unit.and_list 
+    [  Unit.assert_is_ok result_alice "first batch should have succeeded"
+    ;  Unit.assert_rejected result_bob  "second batch should have failed"
+    ;  Unit.assert_equals 1n (storage.max_index) "max_index should be 1: the second batch failed"
+    ;  Unit.assert_equals (Some first_batch) (get_batch (1n, storage)) "the batch should have been stored"
+    ]
+
+(* Creation of test suite *)
+let suite = Unit.make_suite
+"Chain_sc"
+"Test suite of bridge storage of batches"
+[  Unit.make_test "First block: success" "test sending first block"  _test_receive_first_block           
+;  Unit.make_test "Second block: success" "sending a son" _test_receive_son                   
+;  Unit.make_test "Second block: failure" "sending an orphan" _test_receive_orphan           
+]

--- a/layer1/chain/test/test_chain_sc.mligo
+++ b/layer1/chain/test/test_chain_sc.mligo
@@ -7,7 +7,7 @@ type originated_chain = (chain_parameter, chain_storage) originated
 
 let empty_chain : chain = 
     { max_index = 0n 
-    ; batches = (Big_map.empty : (index, batch) big_map)
+    ; blocks = (Big_map.empty : (index, block) big_map)
     ; children = (Big_map.empty : (index, index list) big_map)
     }
 
@@ -15,7 +15,7 @@ let originate_chain () : originated_chain =
     let empty_storage : chain_storage = 
         { empty_chain with
           max_index = 0n 
-        ; batches = (Big_map.empty : (index, batch) big_map)
+        ; blocks = (Big_map.empty : (index, block) big_map)
         ; children = (Big_map.empty : (index, index list) big_map)
         } in
     Unit.originate main empty_storage 0tez
@@ -28,19 +28,19 @@ let _test_receive_first_block () =
     let operator, actors = Unit.init_default () in 
     let alice, _bob, _carol = actors in 
     let chain : originated_chain = Unit.act_as operator originate_chain  in
-    let my_batch  = 
+    let my_block  = 
         {  parent = 0n
         ;  level = 0n
         ;  hash = 0x0101
         ;  proposer = alice.address
         } in 
-    let send_block () = Unit.transfer_to_contract_ chain.originated_contract (Receive my_batch) 0tez in
+    let send_block () = Unit.transfer_to_contract_ chain.originated_contract (Receive my_block) 0tez in
     let result = Unit.act_as alice send_block in
     let storage = Test.get_storage chain.originated_typed_address in
     Unit.and_list 
     [  result 
     ;  Unit.assert_equals 1n (storage.max_index) "max_index should be 1"
-    ;  Unit.assert_equals (Some my_batch) (get_batch (1n, storage)) "the batch should have been stored"
+    ;  Unit.assert_equals (Some my_block) (get_block (1n, storage)) "the block should have been stored"
     ]
 
 
@@ -52,31 +52,31 @@ let _test_receive_son () =
     let chain : originated_chain = Unit.act_as operator originate_chain  in
 
     // act
-    let first_batch  = 
+    let first_block  = 
         {  parent = 0n
         ;  level = 0n
         ;  hash = 0x0101
         ;  proposer = alice.address
         } in 
-    let second_batch = 
+    let second_block = 
         {  parent = 1n
         ;  level = 10n
         ;  hash = 0x0101
         ;  proposer = bob.address
         } in 
-    let send_block (batch : batch) () = Unit.transfer_to_contract_ chain.originated_contract (Receive batch) 0tez in
-    let result_alice = Unit.act_as alice (send_block first_batch) in
-    let result_bob = Unit.act_as bob (send_block second_batch) in
+    let send_block (block : block) () = Unit.transfer_to_contract_ chain.originated_contract (Receive block) 0tez in
+    let result_alice = Unit.act_as alice (send_block first_block) in
+    let result_bob = Unit.act_as bob (send_block second_block) in
 
     // assert
     let storage = Test.get_storage chain.originated_typed_address in
     Unit.and_list 
-    [  Unit.assert_is_ok result_alice "first batch should have succeeded"
-    ;  Unit.assert_is_ok result_bob  "second batch should have succeeded"
+    [  Unit.assert_is_ok result_alice "first block should have succeeded"
+    ;  Unit.assert_is_ok result_bob  "second block should have succeeded"
     ;  Unit.assert_equals 2n (storage.max_index) "max_index should be 2"
-    ;  Unit.assert_equals (Some first_batch) (get_batch (1n, storage)) "the first batch should have been stored"
-    ;  Unit.assert_equals (Some second_batch) (get_batch (2n, storage)) "the second batch should have been stored"
-    ;  Unit.assert_equals (Some [2n]) (get_children (1n, storage)) "second batch is a child of first"
+    ;  Unit.assert_equals (Some first_block) (get_block (1n, storage)) "the first block should have been stored"
+    ;  Unit.assert_equals (Some second_block) (get_block (2n, storage)) "the second block should have been stored"
+    ;  Unit.assert_equals (Some [2n]) (get_children (1n, storage)) "second block is a child of first"
     ]
 
 // test sending an orphan
@@ -87,30 +87,30 @@ let _test_receive_orphan () =
     let chain : originated_chain = Unit.act_as operator originate_chain  in
     
     // act
-    let first_batch  = 
+    let first_block  = 
         {  parent = 0n
         ;  level = 0n
         ;  hash = 0x0101
         ;  proposer = alice.address
         } in 
-    let second_batch = 
+    let second_block = 
         {  parent = 3n
         ;  level = 10n
         ;  hash = 0x0101
         ;  proposer = bob.address
         } in 
-    let send_block (batch : batch) () = Unit.transfer_to_contract_ chain.originated_contract (Receive batch) 0tez in
-    let result_alice = Unit.act_as alice (send_block first_batch) in
-    let result_bob = Unit.act_as bob (send_block second_batch) in
+    let send_block (block : block) () = Unit.transfer_to_contract_ chain.originated_contract (Receive block) 0tez in
+    let result_alice = Unit.act_as alice (send_block first_block) in
+    let result_bob = Unit.act_as bob (send_block second_block) in
 
     // assert
     let storage = Test.get_storage chain.originated_typed_address in
     Unit.and_list 
-    [  Unit.assert_is_ok result_alice "first batch should have succeeded"
-    ;  Unit.assert_rejected result_bob  "second batch should have failed"
-    ;  Unit.assert_equals 1n (storage.max_index) "max_index should be 1: the second batch failed"
-    ;  Unit.assert_equals (Some first_batch) (get_batch (1n, storage)) "the batch should have been stored"
-    ;  Unit.assert_equals (None : index list option) (get_children (1n, storage)) "second batch not recorded as a child of first"
+    [  Unit.assert_is_ok result_alice "first block should have succeeded"
+    ;  Unit.assert_rejected result_bob  "second block should have failed"
+    ;  Unit.assert_equals 1n (storage.max_index) "max_index should be 1: the second block failed"
+    ;  Unit.assert_equals (Some first_block) (get_block (1n, storage)) "the block should have been stored"
+    ;  Unit.assert_equals (None : index list option) (get_children (1n, storage)) "second block not recorded as a child of first"
     ]
 
 
@@ -122,44 +122,44 @@ let _test_receive_siblings () =
     let chain : originated_chain = Unit.act_as operator originate_chain  in
 
     // act
-    let first_batch  = 
+    let first_block  = 
         {  parent = 0n
         ;  level = 0n
         ;  hash = 0x0101
         ;  proposer = alice.address
         } in 
-    let second_batch = 
+    let second_block = 
         {  parent = 1n
         ;  level = 10n
         ;  hash = 0x0101
         ;  proposer = bob.address
         } in 
-    let third_batch = 
+    let third_block = 
         {  parent = 1n
         ;  level = 20n
         ;  hash = 0x0202
         ;  proposer = alice.address
         } in 
-    let send_block (batch : batch) () = Unit.transfer_to_contract_ chain.originated_contract (Receive batch) 0tez in
-    let result_first = Unit.act_as alice (send_block first_batch) in
-    let result_second = Unit.act_as bob (send_block second_batch) in
-    let result_third = Unit.act_as bob (send_block third_batch) in
+    let send_block (block : block) () = Unit.transfer_to_contract_ chain.originated_contract (Receive block) 0tez in
+    let result_first = Unit.act_as alice (send_block first_block) in
+    let result_second = Unit.act_as bob (send_block second_block) in
+    let result_third = Unit.act_as bob (send_block third_block) in
 
     // assert
     let storage = Test.get_storage chain.originated_typed_address in
     Unit.and_list 
-    [  Unit.assert_is_ok result_first "first batch should have succeeded"
-    ;  Unit.assert_is_ok result_second  "second batch should have succeeded"
-    ;  Unit.assert_is_ok result_third  "third batch should have succeeded"
+    [  Unit.assert_is_ok result_first "first block should have succeeded"
+    ;  Unit.assert_is_ok result_second  "second block should have succeeded"
+    ;  Unit.assert_is_ok result_third  "third block should have succeeded"
     ;  Unit.assert_equals 3n (storage.max_index) "max_index should be 3"
-    ;  Unit.assert_equals (Some [3n ; 2n]) (get_children (1n, storage)) "second batch is a child of first"
+    ;  Unit.assert_equals (Some [3n ; 2n]) (get_children (1n, storage)) "second block is a child of first"
     ]
 
 
 (* Creation of test suite *)
 let suite = Unit.make_suite
 "Chain_sc"
-"Test suite of bridge storage of batches"
+"Test suite of bridge storage of blocks"
 [  Unit.make_test "First block: success" "test sending first block"  _test_receive_first_block           
 ;  Unit.make_test "Second block: success" "sending a son" _test_receive_son            
 ;  Unit.make_test "Third block: success" "sending two children for first block" _test_receive_siblings                   

--- a/layer1/chain/test/test_chain_sc.mligo
+++ b/layer1/chain/test/test_chain_sc.mligo
@@ -4,9 +4,18 @@
 (* UTILS *)
 type originated = Unit.originated // FIXME LIGO
 type originated_chain = (chain_parameter, chain_storage) originated
+
+let empty_chain = 
+    { max_index = 0n 
+    ; batches = (Big_map.empty : (index, batch) big_map)
+    ; children = (Big_map.empty : (index, index list) big_map)
+    ; latest_finalized = 0n
+    }
+
 let originate_chain () : originated_chain = 
     let empty_storage : chain_storage = 
-        { max_index = 0n 
+        { empty_chain with
+          max_index = 0n 
         ; batches = (Big_map.empty : (index, batch) big_map)
         ; children = (Big_map.empty : (index, index list) big_map)
         } in

--- a/layer1/chain/test/test_chain_sc.mligo
+++ b/layer1/chain/test/test_chain_sc.mligo
@@ -5,11 +5,10 @@
 type originated = Unit.originated // FIXME LIGO
 type originated_chain = (chain_parameter, chain_storage) originated
 
-let empty_chain = 
+let empty_chain : chain = 
     { max_index = 0n 
     ; batches = (Big_map.empty : (index, batch) big_map)
     ; children = (Big_map.empty : (index, index list) big_map)
-    ; latest_finalized = 0n
     }
 
 let originate_chain () : originated_chain = 

--- a/layer1/chain/test/test_chain_sc.mligo
+++ b/layer1/chain/test/test_chain_sc.mligo
@@ -1,0 +1,159 @@
+#include "../src/chain_sc.mligo"
+#import "../../stdlib_ext/src/unit_test.mligo" "Unit"
+
+(* UTILS *)
+type originated = Unit.originated // FIXME LIGO
+type originated_chain = (chain_parameter, chain_storage) originated
+let originate_chain () : originated_chain = 
+    let empty_storage : chain_storage = 
+        { max_index = 0n 
+        ; batches = (Big_map.empty : (index, batch) big_map)
+        ; children = (Big_map.empty : (index, index list) big_map)
+        } in
+    Unit.originate main empty_storage 0tez
+
+(* TESTS *)
+
+
+// test sending a block
+let _test_receive_first_block () = 
+    let operator, actors = Unit.init_default () in 
+    let alice, _bob, _carol = actors in 
+    let chain : originated_chain = Unit.act_as operator originate_chain  in
+    let my_batch  = 
+        {  parent = 0n
+        ;  level = 0n
+        ;  hash = 0x0101
+        ;  proposer = alice.address
+        } in 
+    let send_block () = Unit.transfer_to_contract_ chain.originated_contract (Receive my_batch) 0tez in
+    let result = Unit.act_as alice send_block in
+    let storage = Test.get_storage chain.originated_typed_address in
+    Unit.and_list 
+    [  result 
+    ;  Unit.assert_equals 1n (storage.max_index) "max_index should be 1"
+    ;  Unit.assert_equals (Some my_batch) (get_batch (1n, storage)) "the batch should have been stored"
+    ]
+
+
+// test sending its son
+let _test_receive_son () = 
+    // setup
+    let operator, actors = Unit.init_default () in 
+    let alice, bob, _carol = actors in 
+    let chain : originated_chain = Unit.act_as operator originate_chain  in
+
+    // act
+    let first_batch  = 
+        {  parent = 0n
+        ;  level = 0n
+        ;  hash = 0x0101
+        ;  proposer = alice.address
+        } in 
+    let second_batch = 
+        {  parent = 1n
+        ;  level = 10n
+        ;  hash = 0x0101
+        ;  proposer = bob.address
+        } in 
+    let send_block (batch : batch) () = Unit.transfer_to_contract_ chain.originated_contract (Receive batch) 0tez in
+    let result_alice = Unit.act_as alice (send_block first_batch) in
+    let result_bob = Unit.act_as bob (send_block second_batch) in
+
+    // assert
+    let storage = Test.get_storage chain.originated_typed_address in
+    Unit.and_list 
+    [  Unit.assert_is_ok result_alice "first batch should have succeeded"
+    ;  Unit.assert_is_ok result_bob  "second batch should have succeeded"
+    ;  Unit.assert_equals 2n (storage.max_index) "max_index should be 2"
+    ;  Unit.assert_equals (Some first_batch) (get_batch (1n, storage)) "the first batch should have been stored"
+    ;  Unit.assert_equals (Some second_batch) (get_batch (2n, storage)) "the second batch should have been stored"
+    ;  Unit.assert_equals (Some [2n]) (get_children (1n, storage)) "second batch is a child of first"
+    ]
+
+// test sending an orphan
+let _test_receive_orphan () = 
+    // setup
+    let operator, actors = Unit.init_default () in 
+    let alice, bob, _carol = actors in 
+    let chain : originated_chain = Unit.act_as operator originate_chain  in
+    
+    // act
+    let first_batch  = 
+        {  parent = 0n
+        ;  level = 0n
+        ;  hash = 0x0101
+        ;  proposer = alice.address
+        } in 
+    let second_batch = 
+        {  parent = 3n
+        ;  level = 10n
+        ;  hash = 0x0101
+        ;  proposer = bob.address
+        } in 
+    let send_block (batch : batch) () = Unit.transfer_to_contract_ chain.originated_contract (Receive batch) 0tez in
+    let result_alice = Unit.act_as alice (send_block first_batch) in
+    let result_bob = Unit.act_as bob (send_block second_batch) in
+
+    // assert
+    let storage = Test.get_storage chain.originated_typed_address in
+    Unit.and_list 
+    [  Unit.assert_is_ok result_alice "first batch should have succeeded"
+    ;  Unit.assert_rejected result_bob  "second batch should have failed"
+    ;  Unit.assert_equals 1n (storage.max_index) "max_index should be 1: the second batch failed"
+    ;  Unit.assert_equals (Some first_batch) (get_batch (1n, storage)) "the batch should have been stored"
+    ;  Unit.assert_equals (None : index list option) (get_children (1n, storage)) "second batch not recorded as a child of first"
+    ]
+
+
+// test sending its son
+let _test_receive_siblings () = 
+    // setup
+    let operator, actors = Unit.init_default () in 
+    let alice, bob, _carol = actors in 
+    let chain : originated_chain = Unit.act_as operator originate_chain  in
+
+    // act
+    let first_batch  = 
+        {  parent = 0n
+        ;  level = 0n
+        ;  hash = 0x0101
+        ;  proposer = alice.address
+        } in 
+    let second_batch = 
+        {  parent = 1n
+        ;  level = 10n
+        ;  hash = 0x0101
+        ;  proposer = bob.address
+        } in 
+    let third_batch = 
+        {  parent = 1n
+        ;  level = 20n
+        ;  hash = 0x0202
+        ;  proposer = alice.address
+        } in 
+    let send_block (batch : batch) () = Unit.transfer_to_contract_ chain.originated_contract (Receive batch) 0tez in
+    let result_first = Unit.act_as alice (send_block first_batch) in
+    let result_second = Unit.act_as bob (send_block second_batch) in
+    let result_third = Unit.act_as bob (send_block third_batch) in
+
+    // assert
+    let storage = Test.get_storage chain.originated_typed_address in
+    Unit.and_list 
+    [  Unit.assert_is_ok result_first "first batch should have succeeded"
+    ;  Unit.assert_is_ok result_second  "second batch should have succeeded"
+    ;  Unit.assert_is_ok result_third  "third batch should have succeeded"
+    ;  Unit.assert_equals 3n (storage.max_index) "max_index should be 3"
+    ;  Unit.assert_equals (Some [3n ; 2n]) (get_children (1n, storage)) "second batch is a child of first"
+    ]
+
+
+(* Creation of test suite *)
+let suite = Unit.make_suite
+"Chain_sc"
+"Test suite of bridge storage of batches"
+[  Unit.make_test "First block: success" "test sending first block"  _test_receive_first_block           
+;  Unit.make_test "Second block: success" "sending a son" _test_receive_son            
+;  Unit.make_test "Third block: success" "sending two children for first block" _test_receive_siblings                   
+;  Unit.make_test "Second block: failure" "sending an orphan" _test_receive_orphan           
+]

--- a/layer1/commons/ticket/chusai_ticket.mligo
+++ b/layer1/commons/ticket/chusai_ticket.mligo
@@ -1,1 +1,1 @@
-#include "tezos_ticket.mligo"
+#include "dummy_ticket.mligo"

--- a/layer1/stdlib_ext/test-framework/assertions.mligo
+++ b/layer1/stdlib_ext/test-framework/assertions.mligo
@@ -25,6 +25,11 @@
 let assert_  (b:bool) (msg:string)  : result = 
     if b then succeed () else fail_with msg
 
+let assert_not_none (type a)  (val: a option) (msg: string) : result = 
+  match val with
+  | Some _ -> succeed ()
+  | None -> fail_with msg
+
 let assert_is_ok (current:result) (msg:string) : result = 
     match current with
     | Test_Failed _ -> fail_with msg

--- a/layer1/test/test.mligo
+++ b/layer1/test/test.mligo
@@ -5,6 +5,7 @@
 #import "../bridge/test/test_inbox_sc.mligo" "Inbox"
 #import "../stdlib_ext/test/suites.mligo" "Stdlib_test"
 #import "../refutation/test/suites.mligo" "Refutation_test"
+#import "../chain/test/test_chain.mligo" "Chain"
 
 let test = 
   Unit.run_suites 
@@ -14,5 +15,6 @@ let test =
     ; Refutation_test.suites
     ; [ Mint.suite ]
     ; [ Inbox.suite ]
+    ; [ Chain.suite ]
     ]
   )

--- a/layer1/test/test.mligo
+++ b/layer1/test/test.mligo
@@ -5,7 +5,7 @@
 #import "../bridge/test/test_inbox_sc.mligo" "Inbox"
 #import "../stdlib_ext/test/suites.mligo" "Stdlib_test"
 #import "../refutation/test/suites.mligo" "Refutation_test"
-#import "../chain/test/test_chain.mligo" "Chain"
+#import "../chain/test/suites.mligo" "Chain"
 
 let test = 
   Unit.run_suites 
@@ -15,6 +15,6 @@ let test =
     ; Refutation_test.suites
     ; [ Mint.suite ]
     ; [ Inbox.suite ]
-    ; [ Chain.suite ]
+    ; Chain.suites 
     ]
   )


### PR DESCRIPTION
A very naïve implementation of the storage of batches. The storage is in a pure functionnal library, with its own tests, a smart contract chain_sc is provided to function as an entrypoint for experimentation. The smart contract is expected to be either deleted or merged into the inbox/bridge contract when all the pieces of layer 1 refutation are put together.

The idea is to provide a temporary storage, to begin work on initialisation of refutation game.