### PR TITLE
DRAFT: [issue 15] Withdraw

### DIFF
--- a/layer1/Makefile
+++ b/layer1/Makefile
@@ -13,7 +13,6 @@ build:
 	make -C wallet build
 	make -C mint build 
 	make -C refutation build
-	make -C chain build
 	make -C bridge build
 
 test:

--- a/layer1/bridge/src/inbox_sc.mligo
+++ b/layer1/bridge/src/inbox_sc.mligo
@@ -1,7 +1,7 @@
 #import "../../commons/inbox_interface.mligo" "Inbox"
 #import "../../commons/transaction.mligo" "Tx"
 #import "../../commons/ticket/chusai_ticket.mligo" "Ticket"
-
+#import "../../chain/src/chain_endpoints.mligo" "Chain"
 #include "../../stdlib_ext/src/stdlibext.mligo"
 
 type message = Inbox.message
@@ -26,6 +26,7 @@ type state = [@layout:comb] {
 ; ticket: Ticket.t option
 ; fixed_ticket_key: ticket_key
 ; inboxes: inboxes
+; chain: Chain.chain
 }
 
 let make_deposit_message (owner: address) (quantity: nat) : message =
@@ -49,10 +50,10 @@ let rec push_message (current_inbox_level : nat) (current_inboxes : inboxes) (me
 let is_same_ticket_key (k1 : ticket_key) (mint_address, payload : address * Ticket.payload) : bool =
   k1.mint_address = mint_address && k1.payload = payload
 
-let deposit (max_inbox_level : nat) (state_ticket : Ticket.t option) (fixed_ticket_key: ticket_key) (inboxes: (nat, message list) big_map) (owner: address) (ticket: Ticket.t) : operation list * state =
-  let (addr, (payload, quantity)), fresh_ticket = Ticket.read_ticket ticket in
+let deposit ({max_inbox_level;ticket;fixed_ticket_key;inboxes;chain} : state) (owner: address) (new_ticket: Ticket.t) : operation list * state =
+  let (addr, (payload, quantity)), fresh_ticket = Ticket.read_ticket new_ticket in
   let opt_joined_ticket = 
-    match state_ticket with
+    match ticket with
     | None -> 
       if is_same_ticket_key fixed_ticket_key (addr,payload) 
         then
@@ -66,22 +67,44 @@ let deposit (max_inbox_level : nat) (state_ticket : Ticket.t option) (fixed_tick
      | Some ticket -> ticket in
   let message = make_deposit_message owner quantity in
   let new_inbox_level, new_inboxes = push_message max_inbox_level inboxes message in
-  let new_state = {  max_inbox_level = new_inbox_level; ticket = (Some joined_ticket) ; fixed_ticket_key = fixed_ticket_key ; inboxes = new_inboxes} in
+  let new_state = {  max_inbox_level = new_inbox_level; ticket = (Some joined_ticket) ; fixed_ticket_key = fixed_ticket_key ; inboxes = new_inboxes ; chain = chain} in
   ([], new_state)
 
-let transaction (max_inbox_level: nat) (source : address) (destination: address) (quantity: nat) (fixed_ticket_key: ticket_key) (inboxes: inboxes) (ticket: Ticket.t option) : operation list * state =
+let transaction ({max_inbox_level;ticket;fixed_ticket_key;inboxes;chain} : state)   (source : address) (destination: address) (quantity: nat) : operation list * state =
   let message = make_transaction_message source destination quantity in
   let new_inbox_level, new_inboxes = push_message max_inbox_level inboxes message in
-  let new_state = {  max_inbox_level = new_inbox_level; ticket = ticket ; fixed_ticket_key = fixed_ticket_key ; inboxes = new_inboxes} in
+  let new_state = {  max_inbox_level = new_inbox_level; ticket = ticket ; fixed_ticket_key = fixed_ticket_key ; inboxes = new_inboxes ; chain = chain} in
   ([], new_state)
 
+let receive ({max_inbox_level;ticket;fixed_ticket_key;inboxes;chain} : state) (proposal : Chain.block_proposal) =
+  let ops, new_chain = Chain.Endpoints.apply_receive (proposal,chain) in
+  let new_state = {  max_inbox_level = max_inbox_level; ticket = ticket ; fixed_ticket_key = fixed_ticket_key ; inboxes = inboxes ; chain = new_chain} in
+  ops, new_state
+
+let remove_block ({max_inbox_level;ticket;fixed_ticket_key;inboxes;chain} : state) (index : Chain.index) =
+  let ops, new_chain = Chain.Endpoints.apply_remove (index,chain)  in
+  let new_state = {  max_inbox_level = max_inbox_level; ticket = ticket ; fixed_ticket_key = fixed_ticket_key ; inboxes = inboxes ; chain = new_chain} in
+  ops, new_state
+
+let finalize_block ({max_inbox_level;ticket;fixed_ticket_key;inboxes;chain} : state) =
+  let ops, new_chain =  Chain.Endpoints.apply_finalize chain  in
+  let new_state = {  max_inbox_level = max_inbox_level; ticket = ticket ; fixed_ticket_key = fixed_ticket_key ; inboxes = inboxes ; chain = new_chain} in
+  ops, new_state
 
 let main (action, state : entrypoint * state) : operation list * state =
-  let {max_inbox_level;ticket;fixed_ticket_key;inboxes} = state in
   match action with
   | Inbox_deposit ticketSent ->
     let ticketSent_owner = Tezos.sender in
-    deposit max_inbox_level ticket fixed_ticket_key inboxes ticketSent_owner ticketSent
+    deposit state ticketSent_owner ticketSent
   | Inbox_transaction { destination; quantity; } ->
     let source = Tezos.sender in
-    transaction max_inbox_level source destination quantity fixed_ticket_key inboxes ticket
+    transaction state  source destination quantity 
+  | Inbox_receive_block proposal -> 
+    receive state proposal
+  | Inbox_remove_block  index -> 
+    remove_block state index
+  | Inbox_finalize_block -> 
+    finalize_block state
+
+[@view] let get_latest ((),state: unit * state) : Chain.block option = Chain.Views.get_latest ((), state.chain)
+[@view] let get_next_finalization_candidate ((), state : unit * state) : Chain.block option = Chain.Views.get_next_finalization_candidate ((), state.chain)

--- a/layer1/bridge/src/inbox_sc.mligo
+++ b/layer1/bridge/src/inbox_sc.mligo
@@ -91,6 +91,11 @@ let finalize_block ({max_inbox_level;ticket;fixed_ticket_key;inboxes;chain} : st
   let new_state = {  max_inbox_level = max_inbox_level; ticket = ticket ; fixed_ticket_key = fixed_ticket_key ; inboxes = inboxes ; chain = new_chain} in
   ops, new_state
 
+let withdraw ({max_inbox_level;ticket;fixed_ticket_key;inboxes;chain} : state) =
+  let ops, new_chain =  Chain.Endpoints.apply_withdraw chain  in
+  let new_state = {  max_inbox_level = max_inbox_level; ticket = ticket ; fixed_ticket_key = fixed_ticket_key ; inboxes = inboxes ; chain = new_chain} in
+  ops, new_state
+
 let main (action, state : entrypoint * state) : operation list * state =
   match action with
   | Inbox_deposit ticketSent ->
@@ -105,6 +110,9 @@ let main (action, state : entrypoint * state) : operation list * state =
     remove_block state index
   | Inbox_finalize_block -> 
     finalize_block state
+  | Inbox_freeze _ -> [], state
+  | Inbox_withdraw ->
+    withdraw state
 
 [@view] let get_latest ((),state: unit * state) : Chain.block option = Chain.Views.get_latest ((), state.chain)
 [@view] let get_next_finalization_candidate ((), state : unit * state) : Chain.block option = Chain.Views.get_next_finalization_candidate ((), state.chain)

--- a/layer1/bridge/test/test_inbox_sc.mligo
+++ b/layer1/bridge/test/test_inbox_sc.mligo
@@ -6,6 +6,8 @@
 #import "../../commons/wallet_interface.mligo" "Wallet_interface"
 #import "../../stdlib_ext/src/unit_test.mligo" "Unit"
 #import "../../wallet/test/unit/tools.mligo" "Tools"
+#import "../../chain/src/chain.mligo" "Chain"
+#import "../../chain/test/utils.mligo" "Chain_utils"
 
 #include "../../stdlib_ext/src/stdlibext.mligo"
 #include "../../stdlib_ext/src/originate_utils.mligo"
@@ -22,17 +24,19 @@ type mint_entrypoint = Mint_interface.mint_parameter
 
 let empty_state (mint : address) : inbox_state = {
     max_inbox_level = 0n
-;   ticket = None
+;   ticket = (None : Ticket.t option)
 ;   fixed_ticket_key = {mint_address= mint; payload= Tools.dummy_payload}
 ;   inboxes = (Big_map.empty : Inbox.inboxes)
+;   chain = Chain_utils.empty_chain
 }
 
 (**same payload but different ticketer**)
 let empty_state2 : inbox_state = {
     max_inbox_level = 0n
-;   ticket = None
+;   ticket = (None : Ticket.t option)
 ;   fixed_ticket_key = {mint_address= ("tz1fVd2fmqYy1TagTo4Pahgad2n3n8GzUX1N" : address); payload= Tools.dummy_payload}
 ;   inboxes = (Big_map.empty : Inbox.inboxes)
+;   chain = Chain_utils.empty_chain
 }
 
 let zero_ticket : Ticket.t = Ticket.create_ticket Tools.dummy_address 0x00 0n

--- a/layer1/bridge/test/test_inbox_sc.mligo
+++ b/layer1/bridge/test/test_inbox_sc.mligo
@@ -8,6 +8,7 @@
 #import "../../wallet/test/unit/tools.mligo" "Tools"
 #import "../../chain/src/chain.mligo" "Chain"
 #import "../../chain/test/utils.mligo" "Chain_utils"
+#import "../../stdlib_ext/src/result.mligo" "Stdlib_Result"
 
 #include "../../stdlib_ext/src/stdlibext.mligo"
 #include "../../stdlib_ext/src/originate_utils.mligo"
@@ -28,6 +29,14 @@ let empty_state (mint : address) : inbox_state = {
 ;   fixed_ticket_key = {mint_address= mint; payload= Tools.dummy_payload}
 ;   inboxes = (Big_map.empty : Inbox.inboxes)
 ;   chain = Chain_utils.empty_chain
+}
+
+let empty_state_chain (mint : address) (chain: Chain.chain) : inbox_state = {
+    max_inbox_level = 0n
+;   ticket = (None : Ticket.t option)
+;   fixed_ticket_key = {mint_address= mint; payload= Tools.dummy_payload}
+;   inboxes = (Big_map.empty : Inbox.inboxes)
+;   chain = chain
 }
 
 (**same payload but different ticketer**)
@@ -255,6 +264,105 @@ let _test_simple_transaction_message () =
     ]
   end
 
+// FIXME: LIGO
+let prototype_block_proposal = Chain_utils.prototype_block_proposal
+
+let _test_simple_send_two_blocks () = 
+  begin
+    log_ "test sending block proposals";
+
+    (* setup *)
+    let operator, actors = Unit.init_default () in
+    let alice, bob, _ = actors in
+    let mint = originate_mint_with () in
+
+    let init_storage = (empty_state mint.originated_address) in
+    let originate_inbox_sc () = Unit.originate Inbox.main init_storage 0tez in
+    let inbox_sc = Unit.act_as operator originate_inbox_sc in
+
+    (* perform *)
+    let inbox_send (proposal : Chain.block_proposal) () = Unit.transfer_to_contract_ inbox_sc.originated_contract (Inbox_receive_block proposal) Chain_utils.bond in
+    let first_block  = 
+        {  prototype_block_proposal with
+           parent = 0n
+        ;  inbox_level = 10n
+        } in 
+    let second_block = 
+        {  prototype_block_proposal with
+           parent = 1n
+        ;  inbox_level = 20n
+        } in 
+    let result_alice = Unit.act_as alice (inbox_send first_block) in
+    let result_bob = Unit.act_as bob (inbox_send second_block) in
+    let storage = Test.get_storage inbox_sc.originated_typed_address in
+    let chain = storage.chain in
+
+
+    (* check *)
+    Unit.and_list
+    [  Unit.assert_is_ok result_alice "first block should have succeeded"
+    ;  Unit.assert_is_ok result_bob  "second block should have succeeded"
+    ;  Unit.assert_equals 2n (chain.max_index) "max_index should be 2"
+    ;  Unit.assert_ (Chain_utils.compare_proposal_and_block first_block (Chain.get_block (1n, chain))) "the first block should have been stored"
+    ;  Unit.assert_ (Chain_utils.compare_proposal_and_block second_block (Chain.get_block (2n, chain))) "the second block should have been stored"
+    ;  Unit.assert_equals (Some [2n]) (Chain.get_children (1n, chain)) "second block is a child of first"
+    ]
+  end
+
+//FIXME: LIGO  
+let empty_chain = Chain_utils.empty_chain
+type result = Stdlib_Result.t
+
+let _test_simple_finalize () =
+  begin
+    log_ "test sending block proposals";
+
+    (* setup *)
+    let operator, actors = Unit.init_default_at ("2020-01-01t10:10:10Z" : timestamp)in
+    let alice, bob, _ = actors in    
+    let mint = originate_mint_with () in
+    let alice_initial_balance = Test.get_balance alice.address in
+
+    let block_alice  = 
+        let b = Chain_utils.block 1n 0n 10n  in 
+        {b with proposer = alice.address} 
+        in
+    let init_chain = 
+        { empty_chain with
+          max_index = 1n 
+        ; blocks = Big_map.literal [(1n, block_alice)]
+        ; children = Big_map.literal [(0n, [1n])]
+        } in
+
+    // sanity check
+    let candidate = Chain.get_finalization_candidate init_chain in
+    let sanity_check = 
+        Unit.and_lazy_list 
+        [  fun () -> Unit.assert_ (Stdlib_Result.is_ok candidate) "a candidate should have been found"
+        ;  fun () -> Unit.assert_equals ((Ok block_alice) : (Chain.block, Chain.chain_error) result ) candidate "alice's block should be next candidate"
+        ] in
+
+    let init_storage = (empty_state_chain mint.originated_address init_chain) in
+    let originate_inbox_sc () = Unit.originate Inbox.main init_storage Chain_utils.bond in
+    let inbox_sc = Unit.act_as operator originate_inbox_sc in
+
+    (* perform *)
+    let inbox_finalize () = Unit.transfer_to_contract_ inbox_sc.originated_contract (Inbox_finalize_block) Chain_utils.bond  in
+    let result = Unit.act_as operator inbox_finalize in
+
+    (* check *)
+    let storage = Test.get_storage inbox_sc.originated_typed_address in
+    let alice_new_balance = Test.get_balance alice.address in
+    let chain = storage.chain in
+    Unit.and_list 
+    [  sanity_check 
+    ;  Unit.assert_is_ok result "finalization should have succeeded" 
+    ;  Unit.assert_equals 1n chain.latest_finalized "block 1n should have been finalize"
+    ;  Unit.assert_equals (alice_initial_balance + Chain_utils.bond) alice_new_balance "Alice should have received the reward"
+    ]
+
+  end
+
 let suite = Unit.make_suite
 "Bridge_sc"
 "Test suite of Bridge sc"
@@ -265,4 +373,6 @@ let suite = Unit.make_suite
 ; Unit.make_test "failure test deposit 3" "A fail test with a deposit with a different ticketer and payload than the ones fixed at inbox originattion" _test_fail_entire_key_deposit
 ; Unit.make_test "should reject deposit" "A test which verify that the 0-value ticket deposit is rejected" _test_fail_0ticket_deposit
 ; Unit.make_test "successful make a transaction" "test to make a transaction message" _test_simple_transaction_message
+; Unit.make_test "successful reception of block proposal" "test that block are correctly received" _test_simple_send_two_blocks
+; Unit.make_test "successful finalization of block" "test that a block can be finalized" _test_simple_finalize
 ]

--- a/layer1/chain/Makefile
+++ b/layer1/chain/Makefile
@@ -1,5 +1,0 @@
-
-.PHONY:build
-build:
-	$(LIGO_BUILD) chain/src/chain_sc.mligo > $(LAYER1_BUILD_DIR)/chain_sc.tez
-

--- a/layer1/chain/src/chain_endpoints.mligo
+++ b/layer1/chain/src/chain_endpoints.mligo
@@ -1,0 +1,68 @@
+
+#include "chain.mligo"
+#import "../../stdlib_ext/src/result.mligo" "Result"
+#import "../../stdlib_ext/src/stdlibext.mligo" "Stdlib_ext"
+
+module Endpoints = struct
+let reward (block, chain : block * chain) : operation list =
+    match (Tezos.get_contract_opt block.proposer : unit contract option) with
+    | None -> 
+        // could not find proposer, but we don't want to fail finalization, so just return no op (and dont fail)
+        []
+    | Some winner_contract -> 
+        // reward         
+        [Tezos.transaction () chain.bond_amount winner_contract]
+
+
+
+let apply_finalize (store : chain) : operation list * chain = 
+    match get_finalization_candidate store with
+    | Error e -> 
+        failwith ("Error during finalization:" ^ (pp_chain_error e))
+    | Ok candidate -> 
+            if is_old_enough (candidate, store, Tezos.now) then
+                reward (candidate, store), finalize (candidate, store)
+            else 
+                failwith "Error during finalization: finality period not finished"
+
+let apply_receive (proposal, store : block_proposal * chain) : operation list * chain =
+        // recolt bond
+        if Tezos.amount < store.bond_amount then 
+            failwith "not enough bond"
+        else
+        // store block
+        begin 
+            let new_store = increase_index store in
+            let block = make_block (proposal, new_store.max_index, Tezos.source, Tezos.now) in
+            match store_block (block, new_store) with
+            | Error _ -> 
+                failwith "could not store"
+            | Ok c -> 
+                 ([] : operation list) , c 
+        end
+
+(* removes a block, making sure to compensate every body who proposed a block based on the removed on (recursively) 
+   /!\ this is for test. Depending on the situation, a proper removal (after refutation) might use a more complexe reimbursement strategy
+*)
+let apply_remove (i, store : index * chain) =
+    let rec reward_deleted (ops, blocks, store : operation list * block list * chain) : operation list = 
+        match blocks with
+        | [] -> ops
+        | b :: q -> 
+            let reward_ops = reward (b, store) in
+            let new_ops = Stdlib_ext.ListExt.concat reward_ops ops in
+            reward_deleted (new_ops, q, store)
+    in
+    let blocks, chain = remove_block (i, store) in
+    let ops = reward_deleted (([] : operation list) , blocks, chain) in
+    ops, chain
+end
+
+module Views = struct
+
+    let get_latest ((),s: unit * chain) : block option = find_latest_existing s
+    let get_next_finalization_candidate ((), s : unit * chain) : block option =
+        match get_finalization_candidate s with
+        | Error e -> None
+        | Ok b -> Some b
+end

--- a/layer1/chain/src/chain_sc.mligo
+++ b/layer1/chain/src/chain_sc.mligo
@@ -2,80 +2,26 @@
     This smart contract is used only as a placeholder to try the /chain/ library. 
 *)
 
-#include "chain.mligo"
+// #import "chain.mligo" "Chain_lib"
 #import "../../stdlib_ext/src/result.mligo" "Result"
 #import "../../stdlib_ext/src/stdlibext.mligo" "Stdlib_ext"
+#import "chain_endpoints.mligo" "Chain"
 
-type chain_storage = chain
+type chain_storage = Chain.chain
 type chain_parameter = 
-    | Receive of block_proposal
-    | Remove  of index // only provided for test. In bridge, removal only happens at the end of a refutation (or if sibling is finalized ?)
+    | Receive of Chain.block_proposal
+    | Remove  of Chain.index // only provided for test. In bridge, removal only happens at the end of a refutation (or if sibling is finalized ?)
     | Finalize
 
-let reward (block, chain : block * chain) : operation list =
-    match (Tezos.get_contract_opt block.proposer : unit contract option) with
-    | None -> 
-        // could not find proposer, but we don't want to fail finalization, so just return no op (and dont fail)
-        []
-    | Some winner_contract -> 
-        // reward         
-        [Tezos.transaction () chain.bond_amount winner_contract]
-
-
-
-let apply_finalize (store : chain_storage) : operation list * chain_storage = 
-    match get_finalization_candidate store with
-    | Error e -> 
-        failwith ("Error during finalization:" ^ (pp_chain_error e))
-    | Ok candidate -> 
-            if is_old_enough (candidate, store, Tezos.now) then
-                reward (candidate, store), finalize (candidate, store)
-            else 
-                failwith "Error during finalization: finality period not finished"
-
-let apply_receive (proposal, store : block_proposal * chain_storage) : operation list * chain_storage =
-        // recolt bond
-        if Tezos.amount < store.bond_amount then 
-            failwith "not enough bond"
-        else
-        // store block
-        begin 
-            let new_store = increase_index store in
-            let block = make_block (proposal, new_store.max_index, Tezos.source, Tezos.now) in
-            match store_block (block, new_store) with
-            | Error _ -> 
-                failwith "could not store"
-            | Ok c -> 
-                 ([] : operation list) , c 
-        end
-
-(* removes a block, making sure to compensate every body who proposed a block based on the removed on (recursively) 
-   /!\ this is for test. Depending on the situation, a proper removal (after refutation) might use a more complexe reimbursement strategy
-*)
-let apply_remove (i, store : index * chain_storage) =
-    let rec reward_deleted (ops, blocks, store : operation list * block list * chain_storage) : operation list = 
-        match blocks with
-        | [] -> ops
-        | b :: q -> 
-            let reward_ops = reward (b, store) in
-            let new_ops = Stdlib_ext.ListExt.concat reward_ops ops in
-            reward_deleted (new_ops, q, store)
-    in
-    let blocks, chain = remove_block (i, store) in
-    let ops = reward_deleted (([] : operation list) , blocks, chain) in
-    ops, chain
 
 (* ENDPOINTS *)
 let main (action, store : chain_parameter * chain_storage) : operation list * chain_storage = 
     match action with
-    | Receive b -> apply_receive (b, store)
-    | Finalize -> apply_finalize store
-    | Remove i -> apply_remove (i, store)
+    | Receive b -> Chain.Endpoints.apply_receive (b, store)
+    | Finalize -> Chain.Endpoints.apply_finalize store
+    | Remove i -> Chain.Endpoints.apply_remove (i, store)
 
 (* VIEWS *) 
 
-[@view] let get_latest ((),s: unit * chain_storage) : block option = find_latest_existing s
-[@view] let get_next_finalization_candidate ((), s : unit * chain_storage) : block option =
-    match get_finalization_candidate s with
-    | Error e -> None
-    | Ok b -> Some b
+[@view] let get_latest = Chain.Views.get_latest
+[@view] let get_next_finalization_candidate = Chain.Views.get_next_finalization_candidate

--- a/layer1/chain/test/chain_sc.mligo
+++ b/layer1/chain/test/chain_sc.mligo
@@ -12,6 +12,7 @@ type chain_parameter =
     | Receive of Chain.block_proposal
     | Remove  of Chain.index // only provided for test. In bridge, removal only happens at the end of a refutation (or if sibling is finalized ?)
     | Finalize
+    | Withdraw
 
 
 (* ENDPOINTS *)
@@ -20,6 +21,7 @@ let main (action, store : chain_parameter * chain_storage) : operation list * ch
     | Receive b -> Chain.Endpoints.apply_receive (b, store)
     | Finalize -> Chain.Endpoints.apply_finalize store
     | Remove i -> Chain.Endpoints.apply_remove (i, store)
+    | Withdraw -> Chain.Endpoints.apply_withdraw store
 
 (* VIEWS *) 
 

--- a/layer1/chain/test/chain_sc.mligo
+++ b/layer1/chain/test/chain_sc.mligo
@@ -5,7 +5,7 @@
 // #import "chain.mligo" "Chain_lib"
 #import "../../stdlib_ext/src/result.mligo" "Result"
 #import "../../stdlib_ext/src/stdlibext.mligo" "Stdlib_ext"
-#import "chain_endpoints.mligo" "Chain"
+#import "../src/chain_endpoints.mligo" "Chain"
 
 type chain_storage = Chain.chain
 type chain_parameter = 

--- a/layer1/chain/test/suites.mligo
+++ b/layer1/chain/test/suites.mligo
@@ -3,5 +3,6 @@
 #import "test_chain.mligo" "Lib"
 #import "test_finalize.mligo" "Finalize_lib"
 #import "test_withdraw.mligo" "Withdraw_lib"
+#import "test_sc_withdraw.mligo" "Withdraw_sc"
 #import "../../stdlib_ext/src/unit_test.mligo" "Unit"
-let suites = [Receive_sc.suite ; Finalize_sc.suite ; Finalize_lib.suite ; Lib.suite ; Withdraw_lib.suite]
+let suites = [  Receive_sc.suite ; Finalize_sc.suite ; Finalize_lib.suite ; Lib.suite ; Withdraw_lib.suite ; Withdraw_sc.suite ]

--- a/layer1/chain/test/suites.mligo
+++ b/layer1/chain/test/suites.mligo
@@ -2,5 +2,6 @@
 #import "test_sc_finalize.mligo" "Finalize_sc"
 #import "test_chain.mligo" "Lib"
 #import "test_finalize.mligo" "Finalize_lib"
+#import "test_withdraw.mligo" "Withdraw_lib"
 #import "../../stdlib_ext/src/unit_test.mligo" "Unit"
-let suites = [Receive_sc.suite ; Finalize_sc.suite ; Finalize_lib.suite ; Lib.suite]
+let suites = [Receive_sc.suite ; Finalize_sc.suite ; Finalize_lib.suite ; Lib.suite ; Withdraw_lib.suite]

--- a/layer1/chain/test/test_sc_finalize.mligo
+++ b/layer1/chain/test/test_sc_finalize.mligo
@@ -1,4 +1,4 @@
-#include "../src/chain_sc.mligo"
+#include "../test/chain_sc.mligo"
 #include "utils.mligo"
 #import "../../stdlib_ext/src/unit_test.mligo" "Unit"
 

--- a/layer1/chain/test/test_sc_receive.mligo
+++ b/layer1/chain/test/test_sc_receive.mligo
@@ -1,4 +1,4 @@
-#include "../src/chain_sc.mligo"
+#include "../test/chain_sc.mligo"
 #import "../../stdlib_ext/src/unit_test.mligo" "Unit"
 #include "utils.mligo"
 (* UTILS *)

--- a/layer1/chain/test/test_sc_withdraw.mligo
+++ b/layer1/chain/test/test_sc_withdraw.mligo
@@ -1,0 +1,55 @@
+#include "../test/chain_sc.mligo"
+#include "utils.mligo"
+#import "../../stdlib_ext/src/unit_test.mligo" "Unit"
+
+type actor = Unit.actor
+(* UTILS *)
+
+let send_proposal (actor : actor) (proposal : block_proposal) (chain : originated_chain) = 
+    let _ = Test.compile_value (Receive proposal) in 
+    let send_block () = Unit.transfer_to_contract_ chain.originated_contract (Receive proposal) bond in
+    Unit.act_as actor send_block
+
+(* TESTS *)
+
+
+// test sending a block
+let _test_withdraw () = 
+    let operator, actors = Unit.init_default_at ("2020-01-01t10:10:10Z" : timestamp) in 
+    let alice, _bob, _carol = actors in 
+    let asset : frozen_amount = 10000000n in // should be high enough to compensate for gas
+    let init_chain = 
+        { empty_chain with
+          max_index = 1n 
+        ; freezer = Big_map.literal [(alice.address, asset)]
+        } in
+    // sanity check
+    let assets_opt, new_chain = withdraw (alice.address, init_chain) in
+    let sanity_check = Unit.and_list 
+    [  Unit.assert_equals (Some asset) assets_opt "Alice should have some assets to withdraw"
+    ;  Unit.assert_equals (None : frozen_amount option) (Big_map.find_opt alice.address new_chain.freezer) "There should be no more asset to withdraw"
+    ] in
+
+    // origination
+    let chain : originated_chain = Unit.act_as operator (originate_chain_with init_chain (asset * 1mutez))  in
+    let alice_initial_balance = Test.get_balance alice.address in
+
+    // act
+    let finalize_result = Unit.act_as alice (fun () -> Unit.transfer_to_contract_ chain.originated_contract Withdraw 0tez) in
+
+    //assert
+    let storage = Test.get_storage chain.originated_typed_address in
+    let alice_new_balance = Test.get_balance alice.address in
+    Unit.and_list 
+    [  sanity_check
+    ;  Unit.assert_is_ok finalize_result "withdrawal should have succeeded" 
+    ;  Unit.assert_ (alice_initial_balance < alice_new_balance) "Alice should have received the funds"
+    ]
+
+
+(* Creation of test suite *)
+let suite = Unit.make_suite
+"Chain_sc : withdraw"
+"Test suite of withdrawal"
+[  Unit.make_test "simple withdrawal" "test straightforward withdraw"  _test_withdraw               
+]

--- a/layer1/chain/test/test_withdraw.mligo
+++ b/layer1/chain/test/test_withdraw.mligo
@@ -1,0 +1,71 @@
+#include "../src/chain.mligo"
+#include "utils.mligo"
+#import "../../stdlib_ext/src/unit_test.mligo" "Unit"
+#import "../../stdlib_ext/src/result.mligo" "Stdlib_Result"
+
+let _test_set_aside_none () = 
+    let alice : user = ("tz1KqTpEZ7Yob7QbPE4Hy4Wo8fHG8LhKxZSx" : address) in
+    let chain = empty_chain in
+    let block = { prototype_block with
+        cooler = Map.literal [(alice, 42n)]
+    } in
+    let new_chain = set_aside_frozen_assets (block,chain) in
+    Unit.assert_equals (Some 42n) (Big_map.find_opt alice new_chain.freezer) "Alice should have some assets available"
+
+let _test_set_aside_some () = 
+    let alice : user = ("tz1KqTpEZ7Yob7QbPE4Hy4Wo8fHG8LhKxZSx" : address) in
+    let chain = {empty_chain with 
+        freezer = Big_map.literal [(alice, 100n)]
+    } in
+    let block = { prototype_block with
+        cooler = Map.literal [(alice, 42n)]
+    } in
+    let new_chain = set_aside_frozen_assets (block,chain) in
+    Unit.assert_equals (Some 142n) (Big_map.find_opt alice new_chain.freezer) "Alice should have more assets available"
+
+
+let _test_set_aside_multiple () = 
+    let alice : user = ("tz1KqTpEZ7Yob7QbPE4Hy4Wo8fHG8LhKxZSx" : address) in
+    let bob : user = ("tz1gjaF81ZRRvdzjobyfVNsAeSC6PScjfQwN" : address) in
+    let chain = {empty_chain with 
+        freezer = Big_map.literal [(alice, 100n) ; (bob, 1000n)]
+    } in
+    let block = { prototype_block with
+        cooler = Map.literal [(alice, 42n) ; (bob, 24n)]
+    } in
+    let new_chain = set_aside_frozen_assets (block,chain) in
+    Unit.and_list
+    [  Unit.assert_equals (Some 142n) (Big_map.find_opt alice new_chain.freezer) "Alice should have more assets available"
+    ;  Unit.assert_equals (Some 1024n) (Big_map.find_opt bob new_chain.freezer) "Bob should have more assets available"
+    ]
+
+let _test_withdraw_some () =
+    let alice : user = ("tz1KqTpEZ7Yob7QbPE4Hy4Wo8fHG8LhKxZSx" : address) in
+    let chain = {empty_chain with 
+        freezer = Big_map.literal [(alice, 100n)]
+    } in
+    let assets_opt, new_chain = withdraw (alice, chain) in
+    Unit.and_list 
+    [  Unit.assert_equals (Some 100n) assets_opt "Alice should have some assets to withdraw"
+    ;  Unit.assert_equals (None : frozen_amount option) (Big_map.find_opt alice new_chain.freezer) "There should be no more asset to withdraw"
+    ]
+
+let _test_withdraw_none () =
+    let alice : user = ("tz1KqTpEZ7Yob7QbPE4Hy4Wo8fHG8LhKxZSx" : address) in
+    let chain = empty_chain  in
+    let assets_opt, new_chain = withdraw (alice, chain) in
+    Unit.and_list 
+    [  Unit.assert_equals (None : frozen_amount option) assets_opt "Alice should have no assets to withdraw"
+    ;  Unit.assert_equals (None : frozen_amount option) (Big_map.find_opt alice new_chain.freezer) "There should be no asset to withdraw"
+    ]
+
+(* Creation of test suite *)
+let suite = Unit.make_suite
+"Chain: withdraw"
+"Test suite of block storage lib"
+[  Unit.make_test "set aside: none before" "set aside frozen asset for a user with no asset frozen"  _test_set_aside_none
+;  Unit.make_test "set aside: some before" "set aside frozen asset for a user that already have some assets available"  _test_set_aside_some
+;  Unit.make_test "set aside: multiple users" "set aside frozen asset for multiple users that already have some assets available"  _test_set_aside_multiple
+;  Unit.make_test "withdraw: some" "Withdraw asset from the freezer"  _test_withdraw_some
+;  Unit.make_test "withdraw: none" "Try to withdraw assets when there are none"  _test_withdraw_none
+]

--- a/layer1/chain/test/utils.mligo
+++ b/layer1/chain/test/utils.mligo
@@ -10,6 +10,7 @@ let empty_chain : chain =
     ; latest_finalized = 0n
     ; finality_period_in_days = 1n
     ; bond_amount = bond
+    ; freezer = (Big_map.empty : fridge)
     }
 type originated = Unit.originated // FIXME LIGO
 type originated_chain = (chain_parameter, chain_storage) originated
@@ -21,6 +22,7 @@ let prototype_block : block =
     ;  hash = 0x0101
     ;  proposer = ("tz1KqTpEZ7Yob7QbPE4Hy4Wo8fHG8LhKxZSx" : address)
     ;  date_of_proposition = ("2000-01-01t10:10:10Z" : timestamp)
+    ;  cooler = (Map.empty : cooler)
     }
 
 let block (index : index) (parent:index) (inbox_level:nat) : block = 
@@ -34,6 +36,7 @@ let prototype_block_proposal =
     {  parent = 0n
     ;  inbox_level = 0n
     ;  hash = 0x0101
+    ;  cooler = (Map.empty : cooler)
     }
 
 let originate_chain () : originated_chain = 

--- a/layer1/chain/test/utils.mligo
+++ b/layer1/chain/test/utils.mligo
@@ -1,5 +1,5 @@
 #include "../src/chain.mligo"
-#include "../src/chain_sc.mligo"
+#include "../test/chain_sc.mligo"
 #import "../../stdlib_ext/src/unit_test.mligo" "Unit"
 
 let bond : tez = 1000tez

--- a/layer1/chain/test/utils.mligo
+++ b/layer1/chain/test/utils.mligo
@@ -1,5 +1,6 @@
 #include "../src/chain.mligo"
 #include "../src/chain_sc.mligo"
+#import "../../stdlib_ext/src/unit_test.mligo" "Unit"
 
 let bond : tez = 1000tez
 let empty_chain : chain = 

--- a/layer1/commons/inbox_interface.mligo
+++ b/layer1/commons/inbox_interface.mligo
@@ -4,6 +4,7 @@
 
 type message =
   | Deposit of {owner: address; quantity: nat}
+  | Freeze of {owner: address; quantity: nat}
   | Transaction of Tx.transaction
 
 type entrypoint =
@@ -12,3 +13,5 @@ type entrypoint =
   | Inbox_receive_block of Chain.block_proposal
   | Inbox_remove_block  of Chain.index // FIXME: delete when refutation is in place
   | Inbox_finalize_block
+  | Inbox_freeze of {quantity: nat}
+  | Inbox_withdraw

--- a/layer1/commons/inbox_interface.mligo
+++ b/layer1/commons/inbox_interface.mligo
@@ -1,5 +1,6 @@
 #import "ticket/chusai_ticket.mligo" "Ticket"
 #import "transaction.mligo" "Tx"
+#import "../chain/src/chain.mligo" "Chain"
 
 type message =
   | Deposit of {owner: address; quantity: nat}
@@ -8,3 +9,6 @@ type message =
 type entrypoint =
   | Inbox_deposit of Ticket.t
   | Inbox_transaction of { destination : address; quantity : nat;  }
+  | Inbox_receive_block of Chain.block_proposal
+  | Inbox_remove_block  of Chain.index // FIXME: delete when refutation is in place
+  | Inbox_finalize_block

--- a/layer1/commons/inbox_interface.mligo
+++ b/layer1/commons/inbox_interface.mligo
@@ -14,4 +14,4 @@ type entrypoint =
   | Inbox_remove_block  of Chain.index // FIXME: delete when refutation is in place
   | Inbox_finalize_block
   | Inbox_freeze of {quantity: nat}
-  | Inbox_withdraw
+  | Inbox_withdraw of Ticket.t contract

--- a/layer1/commons/wallet_interface.mligo
+++ b/layer1/commons/wallet_interface.mligo
@@ -29,6 +29,8 @@ type bridge_parameter
   | Receive_block of Chain.block_proposal
   | Remove_block  of Chain.index // FIXME: delete when refutation is in place
   | Finalize_block
+  | Freeze of {quantity: nat}
+  | Withdraw
 
 
 type bridge_return = operation list * bridge_storage

--- a/layer1/commons/wallet_interface.mligo
+++ b/layer1/commons/wallet_interface.mligo
@@ -1,4 +1,5 @@
 #import "ticket/chusai_ticket.mligo" "Ticket"
+#import "../chain/src/chain_endpoints.mligo" "Chain"
 
 type chusai_ticket_storage = Ticket.t option
 
@@ -25,5 +26,9 @@ type bridge_storage = {
 type bridge_parameter
   = Deposit of Ticket.t
   | Transaction of { destination : address; quantity : nat;  }
+  | Receive_block of Chain.block_proposal
+  | Remove_block  of Chain.index // FIXME: delete when refutation is in place
+  | Finalize_block
+
 
 type bridge_return = operation list * bridge_storage

--- a/layer1/commons/wallet_interface.mligo
+++ b/layer1/commons/wallet_interface.mligo
@@ -30,7 +30,7 @@ type bridge_parameter
   | Remove_block  of Chain.index // FIXME: delete when refutation is in place
   | Finalize_block
   | Freeze of {quantity: nat}
-  | Withdraw
+  | Withdraw of Ticket.t contract
 
 
 type bridge_return = operation list * bridge_storage

--- a/layer1/wallet/test/unit/fakes.mligo
+++ b/layer1/wallet/test/unit/fakes.mligo
@@ -32,5 +32,5 @@ let fake_bridge_main (parameter, storage: bridge_parameter * bridge_storage) : b
       ([], storage)
     | Freeze _ ->
       ([], storage)
-    | Withdraw ->
+    | Withdraw _ ->
       ([], storage)

--- a/layer1/wallet/test/unit/fakes.mligo
+++ b/layer1/wallet/test/unit/fakes.mligo
@@ -30,3 +30,7 @@ let fake_bridge_main (parameter, storage: bridge_parameter * bridge_storage) : b
       ([], storage)
     | Finalize_block ->
       ([], storage)
+    | Freeze _ ->
+      ([], storage)
+    | Withdraw ->
+      ([], storage)

--- a/layer1/wallet/test/unit/fakes.mligo
+++ b/layer1/wallet/test/unit/fakes.mligo
@@ -24,3 +24,9 @@ let fake_bridge_main (parameter, storage: bridge_parameter * bridge_storage) : b
       ([], new_storage)
     | Transaction _ ->
       ([], storage)
+    | Receive_block _ ->
+      ([], storage)
+    | Remove_block  _ ->
+      ([], storage)
+    | Finalize_block ->
+      ([], storage)


### PR DESCRIPTION
Implementation of withdrawal:
- each block contain a `cooler` section, where is given a description of the assets that were frozen by `Freeze` the `message`s that were processed on layer 2 (a `map`, to allow iteration using `Map.fold`)
- during finalization of a block, those assets are put aside to be available for users to withdraw in a `freezer` (a `big_map`)

Implementation only in the `chain` lib for now. 
The branch was created from `pec@40_finalization` and will be rebased on main if it is merged.
The PR is defined with respect to `pec@40_finalization` to begin discussion on the proposed implementation.

Missing: anything touching the `inbox_ sc` contract is missing for now, waiting for PR#48 to be merged
- `Freeze` message definition
- modification of endpoints of inbox to include `Inbox_freeze of nat` and `Inbox_withdraw`